### PR TITLE
feat: add runs api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "crates/common", "crates/engine", "crates/engines/generic" ]
+members = [ "crates/api", "crates/common", "crates/engine", "crates/engines/generic" ]
 resolver = "3"
 
 [workspace.dependencies]
@@ -21,5 +21,4 @@ tokio = { features = [ "full" ], version = "1.50.0" }
 tracing = "0.1.44"
 tracing-subscriber = { features = [ "env-filter", "json" ], version = "0.3.22" }
 utoipa = { features = [ "axum_extras", "chrono", "uuid" ], version = "5.4.0" }
-utoipa-scalar = { features = [ "axum" ], version = "0.3.0" }
 uuid = { features = [ "serde", "v7" ], version = "1.21.0" }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,0 +1,40 @@
+[[bin]]
+name = "metis-api"
+path = "src/main.rs"
+
+[dependencies]
+async-stream = "0.3.6"
+async-trait = "0.1.89"
+axum = { features = [ "macros" ], version = "0.8.8" }
+axum-extra = { features = [ "query", "typed-header" ], version = "0.12.5" }
+base64 = "0.22.1"
+chrono = { features = [ "serde" ], version = "0.4.44" }
+common = { path = "../common", version = "0.1.0" }
+futures = "0.3.32"
+serde = { features = [ "derive" ], workspace = true }
+serde_json = { workspace = true }
+sqlx = { features = [
+  "chrono",
+  "derive",
+  "json",
+  "macros",
+  "postgres",
+  "runtime-tokio-rustls",
+  "uuid",
+], workspace = true }
+thiserror = "2.0.18"
+tokio = { features = [ "full" ], workspace = true }
+tokio-stream = "0.1.18"
+tower-http = { features = [ "cors", "trace" ], version = "0.6.8" }
+tracing-subscriber = { features = [ "env-filter", "json" ], workspace = true }
+url = "2.5.8"
+utoipa = { features = [ "axum_extras", "chrono", "uuid" ], workspace = true }
+utoipa-swagger-ui = { features = [ "axum" ], version = "9" }
+uuid = { features = [ "serde", "v7" ], workspace = true }
+envy.workspace = true
+tracing.workspace = true
+
+[package]
+edition = "2024"
+name = "metis-api"
+version = "0.1.0"

--- a/crates/api/src/api/error.rs
+++ b/crates/api/src/api/error.rs
@@ -1,0 +1,60 @@
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use common::models::ErrorResponse;
+use utoipa::ToSchema;
+
+use crate::services::ServiceError;
+
+pub type ApiResult<T> = std::result::Result<T, ApiError>;
+
+#[derive(Debug, ToSchema)]
+pub enum ApiError {
+    #[schema(example = "Bad request: invalid parameter")]
+    BadRequest(String),
+
+    #[schema(example = "Unauthorized")]
+    Unauthorized,
+
+    #[schema(example = "Forbidden")]
+    Forbidden,
+
+    #[schema(example = "Run not found: abc123")]
+    NotFound(String),
+
+    #[schema(example = "Internal server error")]
+    Internal(String),
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, msg) = match self {
+            ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized".to_string()),
+            ApiError::Forbidden => (StatusCode::FORBIDDEN, "Forbidden".to_string()),
+            ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
+            ApiError::Internal(msg) => {
+                tracing::error!("Internal error: {}", msg);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error".to_string())
+            },
+        };
+
+        let body = Json(ErrorResponse {
+            msg: Some(msg),
+            status_code: Some(status.as_u16() as i32),
+        });
+
+        (status, body).into_response()
+    }
+}
+
+impl From<ServiceError> for ApiError {
+    fn from(err: ServiceError) -> Self {
+        match err {
+            ServiceError::RunNotFound(id) => ApiError::NotFound(format!("Run not found: {}", id)),
+            ServiceError::TaskNotFound(id) => ApiError::NotFound(format!("Task not found: {}", id)),
+            ServiceError::InvalidFilter(msg) => ApiError::BadRequest(msg),
+            ServiceError::Repository(e) => ApiError::Internal(e.to_string()),
+        }
+    }
+}

--- a/crates/api/src/api/logs.rs
+++ b/crates/api/src/api/logs.rs
@@ -1,0 +1,146 @@
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::response::sse::{Event, Sse};
+use serde::{Deserialize, Serialize};
+use tokio_stream::wrappers::ReceiverStream;
+use utoipa::ToSchema;
+
+use crate::api::ApiResult;
+use crate::extractors::LogPageParams;
+use crate::repositories::RunId;
+use crate::state::AppState;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct LogLineResponse {
+    pub run_id: String,
+    pub stream: String,
+    pub seq: i64,
+    pub line: String,
+    pub written_at: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LogLineListResponse {
+    pub lines: Vec<LogLineResponse>,
+    pub next_after_seq: Option<i64>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/runs/{run_id}/logs",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID"),
+        LogPageParams
+    ),
+    responses(
+        (status = 200, description = "Paginated log lines", body = LogLineListResponse),
+        (status = 404, description = "Run not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn list_log_lines(
+    State(app): State<AppState>,
+    Path(run_id): Path<String>,
+    Query(params): Query<LogPageParams>,
+    Query(stream_filter): Query<StreamFilter>,
+) -> ApiResult<Json<LogLineListResponse>> {
+    let id = RunId::new(run_id);
+    let stream = stream_filter.stream.as_ref().and_then(|s| s.parse().ok());
+    let page_size = params.page_size();
+
+    let result = app.services.logs.find_lines(&id, stream, params.after_seq, page_size).await?;
+
+    let lines: Vec<LogLineResponse> = result
+        .items
+        .into_iter()
+        .map(|l| LogLineResponse {
+            run_id: l.run_id.into_inner(),
+            stream: l.stream.to_string(),
+            seq: l.seq,
+            line: l.line,
+            written_at: l.written_at.to_rfc3339(),
+        })
+        .collect();
+
+    let next_after_seq = lines.last().map(|l| l.seq);
+
+    Ok(Json(LogLineListResponse { lines, next_after_seq }))
+}
+
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct StreamFilter {
+    pub stream: Option<String>,
+}
+
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct AfterSeq {
+    pub after_seq: Option<i64>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/runs/{run_id}/logs/stream",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID"),
+        StreamFilter,
+        AfterSeq
+    ),
+    responses(
+        (status = 200, description = "SSE stream of log lines", content_type = "text/event-stream"),
+        (status = 404, description = "Run not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn stream_log_lines(
+    State(app): State<AppState>,
+    Path(run_id): Path<String>,
+    Query(stream_filter): Query<StreamFilter>,
+    Query(after_seq): Query<AfterSeq>,
+) -> ApiResult<Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>> {
+    let id = RunId::new(run_id.clone());
+    let stream_type = stream_filter.stream.as_ref().and_then(|s| s.parse().ok());
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(100);
+
+    tokio::spawn(async move {
+        let mut current_seq = after_seq.after_seq.unwrap_or(0);
+
+        loop {
+            match app.services.logs.find_lines(&id, stream_type, Some(current_seq), 50).await {
+                Ok(result) => {
+                    if result.items.is_empty() {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                        continue;
+                    }
+
+                    for line in result.items {
+                        current_seq = line.seq;
+
+                        let log_response = LogLineResponse {
+                            run_id: line.run_id.into_inner(),
+                            stream: line.stream.to_string(),
+                            seq: line.seq,
+                            line: line.line,
+                            written_at: line.written_at.to_rfc3339(),
+                        };
+
+                        let json = serde_json::to_string(&log_response).unwrap_or_default();
+                        let event = Event::default().data(json);
+
+                        if tx.send(Ok(event)).await.is_err() {
+                            break;
+                        }
+                    }
+                },
+                Err(e) => {
+                    tracing::error!("Error fetching log lines: {}", e);
+                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                },
+            }
+        }
+    });
+
+    Ok(Sse::new(ReceiverStream::new(rx)))
+}

--- a/crates/api/src/api/logs.rs
+++ b/crates/api/src/api/logs.rs
@@ -130,7 +130,7 @@ pub async fn stream_log_lines(
                         let event = Event::default().data(json);
 
                         if tx.send(Ok(event)).await.is_err() {
-                            break;
+                            return;
                         }
                     }
                 },

--- a/crates/api/src/api/mod.rs
+++ b/crates/api/src/api/mod.rs
@@ -1,0 +1,9 @@
+pub mod error;
+pub mod logs;
+pub mod runs;
+pub mod tasks;
+
+pub use error::{ApiError, ApiResult};
+pub use logs::*;
+pub use runs::*;
+pub use tasks::*;

--- a/crates/api/src/api/runs.rs
+++ b/crates/api/src/api/runs.rs
@@ -1,0 +1,129 @@
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use common::models::{RunListResponse, RunLog, RunStatus};
+
+use crate::api::{ApiError, ApiResult};
+use crate::extractors::{PageParams, RunFilterParams};
+use crate::repositories::RunId;
+use crate::state::AppState;
+
+#[utoipa::path(
+    get,
+    path = "/runs",
+    tag = "Runs",
+    params(PageParams, RunFilterParams),
+    responses(
+        (status = 200, description = "List of workflow runs", body = RunListResponse),
+        (status = 400, description = "Bad request"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn list_runs(
+    State(app): State<AppState>,
+    Query(page): Query<PageParams>,
+    Query(filter): Query<RunFilterParams>,
+) -> ApiResult<Json<RunListResponse>> {
+    let filter = filter.into_filter().map_err(ApiError::BadRequest)?;
+    let pagination = page.into_pagination();
+
+    let result = app.services.runs.find_all(filter, pagination).await?;
+
+    let runs: Vec<common::models::RunListResponseRunsInner> = result
+        .items
+        .into_iter()
+        .map(|r| common::models::RunListResponseRunsInner {
+            run_id: r.id.into_inner(),
+            state: Some(r.state),
+            start_time: r.start_time.map(|t| t.to_rfc3339()),
+            end_time: r.end_time.map(|t| t.to_rfc3339()),
+            tags: serde_json::from_value(r.tags).unwrap_or_default(),
+        })
+        .collect();
+
+    Ok(Json(RunListResponse {
+        runs: Some(runs),
+        next_page_token: result.next_page_token,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/runs/{run_id}",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID")
+    ),
+    responses(
+        (status = 200, description = "Run log details", body = RunLog),
+        (status = 404, description = "Run not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn get_run_log(
+    State(app): State<AppState>,
+    Path(run_id): Path<String>,
+) -> ApiResult<Json<RunLog>> {
+    let id = RunId::new(run_id);
+
+    let run = app
+        .services
+        .runs
+        .find_by_id(&id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Run not found: {}", id)))?;
+
+    let task_logs_url = format!("/runs/{}/tasks", run.id);
+
+    Ok(Json(RunLog {
+        run_id: Some(run.id.into_inner()),
+        request: Some(Box::new(common::models::RunRequest {
+            workflow_params: run.workflow_params,
+            workflow_type: run.workflow_type,
+            workflow_type_version: run.workflow_type_version,
+            tags: serde_json::from_value(run.tags).ok(),
+            workflow_engine_parameters: serde_json::from_value(
+                run.workflow_engine_parameters.unwrap_or(serde_json::Value::Null),
+            )
+            .ok(),
+            workflow_engine: run.workflow_engine,
+            workflow_engine_version: run.workflow_engine_version,
+            workflow_url: run.workflow_url,
+        })),
+        state: Some(run.state),
+        run_log: None,
+        task_logs_url: Some(task_logs_url),
+        outputs: None,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/runs/{run_id}/status",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID")
+    ),
+    responses(
+        (status = 200, description = "Run status", body = RunStatus),
+        (status = 404, description = "Run not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn get_run_status(
+    State(app): State<AppState>,
+    Path(run_id): Path<String>,
+) -> ApiResult<Json<RunStatus>> {
+    let id = RunId::new(run_id);
+
+    let run = app
+        .services
+        .runs
+        .find_by_id(&id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Run not found: {}", id)))?;
+
+    Ok(Json(RunStatus {
+        run_id: run.id.into_inner(),
+        state: Some(run.state),
+    }))
+}

--- a/crates/api/src/api/tasks.rs
+++ b/crates/api/src/api/tasks.rs
@@ -1,0 +1,97 @@
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use common::models::{TaskListResponse, TaskLog};
+
+use crate::api::{ApiError, ApiResult};
+use crate::extractors::PageParams;
+use crate::repositories::{RunId, TaskId};
+use crate::state::AppState;
+
+#[utoipa::path(
+    get,
+    path = "/runs/{run_id}/tasks",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID"),
+        PageParams
+    ),
+    responses(
+        (status = 200, description = "List of tasks", body = TaskListResponse),
+        (status = 404, description = "Run not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn list_tasks(
+    State(app): State<AppState>,
+    Path(run_id): Path<String>,
+    Query(page): Query<PageParams>,
+) -> ApiResult<Json<TaskListResponse>> {
+    let id = RunId::new(run_id);
+    let pagination = page.into_pagination();
+
+    let result = app.services.tasks.find_by_run(&id, pagination).await?;
+
+    let task_logs: Vec<TaskLog> = result
+        .items
+        .into_iter()
+        .map(|t| TaskLog {
+            id: t.id.into_inner(),
+            name: t.name,
+            cmd: t.cmd,
+            start_time: t.start_time.map(|t| t.to_rfc3339()),
+            end_time: t.end_time.map(|t| t.to_rfc3339()),
+            stdout: t.stdout,
+            stderr: t.stderr,
+            exit_code: t.exit_code,
+            system_logs: t.system_logs,
+            tes_uri: t.tes_uri,
+        })
+        .collect();
+
+    Ok(Json(TaskListResponse {
+        task_logs: Some(task_logs),
+        next_page_token: result.next_page_token,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/runs/{run_id}/tasks/{task_id}",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID"),
+        ("task_id" = String, Path, description = "Task ID")
+    ),
+    responses(
+        (status = 200, description = "Task details", body = TaskLog),
+        (status = 404, description = "Task not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn get_task(
+    State(app): State<AppState>,
+    Path((run_id, task_id)): Path<(String, String)>,
+) -> ApiResult<Json<TaskLog>> {
+    let run = RunId::new(run_id);
+    let task = TaskId::new(task_id);
+
+    let t = app
+        .services
+        .tasks
+        .find_by_id(&run, &task)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Task not found: {}", task)))?;
+
+    Ok(Json(TaskLog {
+        id: t.id.into_inner(),
+        name: t.name,
+        cmd: t.cmd,
+        start_time: t.start_time.map(|t| t.to_rfc3339()),
+        end_time: t.end_time.map(|t| t.to_rfc3339()),
+        stdout: t.stdout,
+        stderr: t.stderr,
+        exit_code: t.exit_code,
+        system_logs: t.system_logs,
+        tes_uri: t.tes_uri,
+    }))
+}

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    #[serde(default = "default_port")]
+    pub app_port: u16,
+
+    #[serde(default)]
+    pub database_url: String,
+
+    #[serde(default = "default_auth_url")]
+    pub auth_instructions_url: String,
+}
+
+fn default_port() -> u16 {
+    8080
+}
+
+fn default_auth_url() -> String {
+    "https://example.com/auth".to_string()
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, envy::Error> {
+        envy::from_env()
+    }
+}

--- a/crates/api/src/docs.rs
+++ b/crates/api/src/docs.rs
@@ -1,0 +1,42 @@
+use axum::Router;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+
+use crate::api::logs::{LogLineListResponse, LogLineResponse};
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::runs::list_runs,
+        crate::api::runs::get_run_log,
+        crate::api::runs::get_run_status,
+        crate::api::tasks::list_tasks,
+        crate::api::tasks::get_task,
+        crate::api::logs::list_log_lines,
+        crate::api::logs::stream_log_lines,
+    ),
+    components(
+        schemas(
+            common::models::RunListResponse,
+            common::models::RunLog,
+            common::models::RunStatus,
+            common::models::TaskListResponse,
+            common::models::TaskLog,
+            LogLineResponse,
+            LogLineListResponse,
+        )
+    ),
+    tags(
+        (name = "Runs", description = "Workflow run management endpoints"),
+    ),
+    info(
+        title = "Metis API",
+        version = "0.1.0",
+        description = "Workflow Execution Service API for managing workflow runs"
+    )
+)]
+pub struct ApiDoc;
+
+pub fn docs() -> Router<()> {
+    SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()).into()
+}

--- a/crates/api/src/extractors/filters.rs
+++ b/crates/api/src/extractors/filters.rs
@@ -1,0 +1,55 @@
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
+
+use crate::repositories::{RunFilter, State};
+
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
+pub struct RunFilterParams {
+    #[param(example = "RUNNING")]
+    pub state: Option<String>,
+
+    #[param(example = "user123")]
+    pub user_id: Option<String>,
+
+    #[param(example = "project")]
+    pub tag_key: Option<String>,
+
+    #[param(example = "genomics")]
+    pub tag_value: Option<String>,
+
+    #[param(example = "2024-01-15T10:30:00Z")]
+    pub started_after: Option<String>,
+
+    #[param(example = "2024-01-16T10:30:00Z")]
+    pub started_before: Option<String>,
+}
+
+impl RunFilterParams {
+    pub fn into_filter(self) -> Result<RunFilter, String> {
+        let state = self.state.as_ref().map(|s| State::from_str(s)).transpose()?;
+        let started_after = self.started_after.as_ref().map(|s| parse_datetime(s)).transpose()?;
+        let started_before = self.started_before.as_ref().map(|s| parse_datetime(s)).transpose()?;
+
+        if self.tag_value.is_some() && self.tag_key.is_none() {
+            return Err("tag_key is required when tag_value is provided".to_string());
+        }
+
+        Ok(RunFilter {
+            state,
+            user_id: self.user_id,
+            tag_key: self.tag_key,
+            tag_value: self.tag_value,
+            started_after,
+            started_before,
+        })
+    }
+}
+
+fn parse_datetime(s: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("Invalid datetime format: {}", e))
+}

--- a/crates/api/src/extractors/mod.rs
+++ b/crates/api/src/extractors/mod.rs
@@ -1,0 +1,5 @@
+mod filters;
+mod pagination;
+
+pub use filters::RunFilterParams;
+pub use pagination::{LogPageParams, PageParams};

--- a/crates/api/src/extractors/pagination.rs
+++ b/crates/api/src/extractors/pagination.rs
@@ -11,7 +11,7 @@ pub struct PageParams {
     #[param(example = 50)]
     pub page_size: Option<u32>,
 
-    #[param(example = "eyJvZmZzZXQiOjUwfQ==")]
+    #[param(example = "NTA=")]
     pub page_token: Option<String>,
 }
 

--- a/crates/api/src/extractors/pagination.rs
+++ b/crates/api/src/extractors/pagination.rs
@@ -1,0 +1,40 @@
+use serde::Deserialize;
+use utoipa::IntoParams;
+
+use crate::repositories::Pagination;
+
+const DEFAULT_PAGE_SIZE: u32 = 50;
+const MAX_PAGE_SIZE: u32 = 1000;
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct PageParams {
+    #[param(example = 50)]
+    pub page_size: Option<u32>,
+
+    #[param(example = "eyJvZmZzZXQiOjUwfQ==")]
+    pub page_token: Option<String>,
+}
+
+impl PageParams {
+    pub fn into_pagination(self) -> Pagination {
+        Pagination::new(
+            self.page_size.unwrap_or(DEFAULT_PAGE_SIZE).min(MAX_PAGE_SIZE),
+            self.page_token,
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct LogPageParams {
+    #[param(example = 500)]
+    pub page_size: Option<u32>,
+
+    #[param(example = 42)]
+    pub after_seq: Option<i64>,
+}
+
+impl LogPageParams {
+    pub fn page_size(&self) -> u32 {
+        self.page_size.unwrap_or(500).min(MAX_PAGE_SIZE)
+    }
+}

--- a/crates/api/src/infrastructure/database.rs
+++ b/crates/api/src/infrastructure/database.rs
@@ -1,0 +1,33 @@
+use sqlx::PgPool;
+
+use crate::repositories::RepositoryError;
+
+#[derive(Clone)]
+pub struct Database {
+    pool: PgPool,
+}
+
+impl Database {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn connect(database_url: &str) -> Result<Self, RepositoryError> {
+        let pool = PgPool::connect(database_url)
+            .await
+            .map_err(|e| RepositoryError::PoolError(e.to_string()))?;
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+impl std::ops::Deref for Database {
+    type Target = PgPool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pool
+    }
+}

--- a/crates/api/src/infrastructure/mod.rs
+++ b/crates/api/src/infrastructure/mod.rs
@@ -1,0 +1,3 @@
+mod database;
+
+pub use database::Database;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod api;
+pub mod config;
+pub mod docs;
+pub mod extractors;
+pub mod infrastructure;
+pub mod repositories;
+pub mod routes;
+pub mod services;
+pub mod state;
+
+pub use api::{ApiError, ApiResult};
+pub use config::Config;
+pub use repositories::RepositoryError;
+pub use services::ServiceError;
+pub use state::AppState;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,0 +1,31 @@
+use std::net::SocketAddr;
+
+use metis_api::docs::docs;
+use metis_api::routes::get_router;
+use metis_api::{AppState, Config};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let config = Config::from_env()?;
+    let state = AppState::new(&config).await?;
+
+    let app = get_router(state).merge(docs());
+
+    let addr: SocketAddr = ([0, 0, 0, 0], config.app_port).into();
+    tracing::info!("Listening on {}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/crates/api/src/repositories/error.rs
+++ b/crates/api/src/repositories/error.rs
@@ -1,0 +1,30 @@
+use thiserror::Error;
+
+pub type RepositoryResult<T> = std::result::Result<T, RepositoryError>;
+
+#[derive(Debug, Error)]
+pub enum RepositoryError {
+    #[error("Database error: {0}")]
+    Database(String),
+
+    #[error("Database query failed: {0}")]
+    QueryFailed(String),
+
+    #[error("Entity not found: {0}")]
+    NotFound(String),
+
+    #[error("Connection pool error: {0}")]
+    PoolError(String),
+}
+
+impl From<sqlx::Error> for RepositoryError {
+    fn from(err: sqlx::Error) -> Self {
+        match err {
+            sqlx::Error::RowNotFound => RepositoryError::NotFound("record".to_string()),
+            sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed => {
+                RepositoryError::PoolError(err.to_string())
+            },
+            _ => RepositoryError::Database(err.to_string()),
+        }
+    }
+}

--- a/crates/api/src/repositories/log.rs
+++ b/crates/api/src/repositories/log.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use sqlx::{PgPool, Row};
+
+use super::{LogLine, LogStream, PaginatedResult, RepositoryResult, RunId};
+
+#[async_trait]
+pub trait LogRepository: Send + Sync {
+    async fn find_lines(
+        &self,
+        run_id: &RunId,
+        stream: Option<LogStream>,
+        after_seq: Option<i64>,
+        page_size: u32,
+    ) -> RepositoryResult<PaginatedResult<LogLine>>;
+}
+
+pub struct SqlxLogRepository {
+    pool: PgPool,
+}
+
+impl SqlxLogRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl LogRepository for SqlxLogRepository {
+    async fn find_lines(
+        &self,
+        run_id: &RunId,
+        stream: Option<LogStream>,
+        after_seq: Option<i64>,
+        page_size: u32,
+    ) -> RepositoryResult<PaginatedResult<LogLine>> {
+        let limit = page_size as i64 + 1;
+
+        let rows = sqlx::query(
+            r#"
+            SELECT run_id, stream, seq, line, written_at
+            FROM log_lines
+            WHERE run_id = $1
+            AND ($2::text IS NULL OR stream = $2)
+            AND ($3::bigint IS NULL OR seq > $3)
+            ORDER BY seq ASC
+            LIMIT $4
+            "#,
+        )
+        .bind(run_id.as_str())
+        .bind(stream.map(|s| s.to_string()))
+        .bind(after_seq)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let lines: Vec<LogLine> = rows.into_iter().map(map_row_to_log_line).collect();
+
+        let has_more = lines.len() > page_size as usize;
+        let items: Vec<LogLine> = lines.into_iter().take(page_size as usize).collect();
+
+        let next_page_token = if has_more {
+            items.last().map(|l| l.seq.to_string())
+        } else {
+            None
+        };
+
+        Ok(PaginatedResult { items, next_page_token })
+    }
+}
+
+fn map_row_to_log_line(row: sqlx::postgres::PgRow) -> LogLine {
+    LogLine {
+        run_id: RunId::new(row.get::<String, _>("run_id")),
+        stream: parse_stream(&row.get::<String, _>("stream")),
+        seq: row.get("seq"),
+        line: row.get("line"),
+        written_at: row.get("written_at"),
+    }
+}
+
+fn parse_stream(s: &str) -> LogStream {
+    match s {
+        "stdout" => LogStream::Stdout,
+        "stderr" => LogStream::Stderr,
+        _ => LogStream::Stdout,
+    }
+}

--- a/crates/api/src/repositories/mod.rs
+++ b/crates/api/src/repositories/mod.rs
@@ -1,11 +1,13 @@
 mod error;
 mod log;
+mod pagination;
 mod run;
 mod schema;
 mod task;
 
 pub use error::{RepositoryError, RepositoryResult};
 pub use log::{LogRepository, SqlxLogRepository};
+pub use pagination::{calculate_next_token, decode_offset, encode_offset, pagination_offset};
 pub use run::{PaginatedResult, Pagination, RunFilter, RunRepository, SqlxRunRepository};
 pub use schema::{LogLine, LogStream, Run, RunId, State, Task, TaskId};
 pub use task::{SqlxTaskRepository, TaskRepository};

--- a/crates/api/src/repositories/mod.rs
+++ b/crates/api/src/repositories/mod.rs
@@ -1,0 +1,11 @@
+mod error;
+mod log;
+mod run;
+mod schema;
+mod task;
+
+pub use error::{RepositoryError, RepositoryResult};
+pub use log::{LogRepository, SqlxLogRepository};
+pub use run::{PaginatedResult, Pagination, RunFilter, RunRepository, SqlxRunRepository};
+pub use schema::{LogLine, LogStream, Run, RunId, State, Task, TaskId};
+pub use task::{SqlxTaskRepository, TaskRepository};

--- a/crates/api/src/repositories/pagination.rs
+++ b/crates/api/src/repositories/pagination.rs
@@ -1,0 +1,31 @@
+use base64::Engine;
+
+use super::{PaginatedResult, Pagination};
+
+pub fn decode_offset(token: &Option<String>) -> Option<u64> {
+    token.as_ref().and_then(|t| {
+        let decoded = base64::engine::general_purpose::STANDARD.decode(t).ok()?;
+        String::from_utf8(decoded).ok()?.parse().ok()
+    })
+}
+
+pub fn encode_offset(offset: u64) -> String {
+    base64::engine::general_purpose::STANDARD.encode(offset.to_string())
+}
+
+pub fn calculate_next_token<T>(items: Vec<T>, page_size: u32, offset: u64) -> PaginatedResult<T> {
+    let has_more = items.len() > page_size as usize;
+    let items = items.into_iter().take(page_size as usize).collect();
+
+    let next_page_token = if has_more {
+        Some(encode_offset(offset + page_size as u64))
+    } else {
+        None
+    };
+
+    PaginatedResult { items, next_page_token }
+}
+
+pub fn pagination_offset(pagination: &Pagination) -> u64 {
+    decode_offset(&pagination.page_token).unwrap_or(0)
+}

--- a/crates/api/src/repositories/run.rs
+++ b/crates/api/src/repositories/run.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use base64::Engine;
 use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row};
 
-use super::{RepositoryResult, Run, RunId, State};
+use super::{RepositoryResult, Run, RunId, State, calculate_next_token, pagination_offset};
 
 #[async_trait]
 pub trait RunRepository: Send + Sync {
@@ -54,7 +53,7 @@ impl RunRepository for SqlxRunRepository {
         filter: RunFilter,
         pagination: Pagination,
     ) -> RepositoryResult<PaginatedResult<Run>> {
-        let offset = decode_offset(&pagination.page_token).unwrap_or(0);
+        let offset = pagination_offset(&pagination);
         let limit = pagination.page_size as i64;
 
         let mut query_str = String::from(
@@ -119,16 +118,7 @@ impl RunRepository for SqlxRunRepository {
 
         let runs: Vec<Run> = rows.into_iter().map(map_row_to_run).collect();
 
-        let has_more = runs.len() > pagination.page_size as usize;
-        let items: Vec<Run> = runs.into_iter().take(pagination.page_size as usize).collect();
-
-        let next_page_token = if has_more {
-            Some(encode_offset(offset + pagination.page_size as u64))
-        } else {
-            None
-        };
-
-        Ok(PaginatedResult { items, next_page_token })
+        Ok(calculate_next_token(runs, pagination.page_size, offset))
     }
 
     async fn count_by_state(&self) -> RepositoryResult<HashMap<String, i64>> {
@@ -162,17 +152,6 @@ fn map_row_to_run(row: sqlx::postgres::PgRow) -> Run {
         end_time: row.get("end_time"),
         created_at: row.get("created_at"),
     }
-}
-
-fn decode_offset(token: &Option<String>) -> Option<u64> {
-    token.as_ref().and_then(|t| {
-        let decoded = base64::engine::general_purpose::STANDARD.decode(t).ok()?;
-        String::from_utf8(decoded).ok()?.parse().ok()
-    })
-}
-
-fn encode_offset(offset: u64) -> String {
-    base64::engine::general_purpose::STANDARD.encode(offset.to_string())
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/api/src/repositories/run.rs
+++ b/crates/api/src/repositories/run.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use base64::Engine;
+use chrono::{DateTime, Utc};
+use sqlx::{PgPool, Row};
+
+use super::{RepositoryResult, Run, RunId, State};
+
+#[async_trait]
+pub trait RunRepository: Send + Sync {
+    async fn find_by_id(&self, id: &RunId) -> RepositoryResult<Option<Run>>;
+    async fn find_all(
+        &self,
+        filter: RunFilter,
+        pagination: Pagination,
+    ) -> RepositoryResult<PaginatedResult<Run>>;
+    async fn count_by_state(&self) -> RepositoryResult<HashMap<String, i64>>;
+}
+
+pub struct SqlxRunRepository {
+    pool: PgPool,
+}
+
+impl SqlxRunRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl RunRepository for SqlxRunRepository {
+    async fn find_by_id(&self, id: &RunId) -> RepositoryResult<Option<Run>> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                run_id, user_id, state, workflow_type, workflow_type_version,
+                workflow_url, workflow_engine, workflow_engine_version,
+                workflow_params, workflow_engine_parameters, tags,
+                start_time, end_time, created_at
+            FROM runs
+            WHERE run_id = $1
+            "#,
+        )
+        .bind(id.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(map_row_to_run))
+    }
+
+    async fn find_all(
+        &self,
+        filter: RunFilter,
+        pagination: Pagination,
+    ) -> RepositoryResult<PaginatedResult<Run>> {
+        let offset = decode_offset(&pagination.page_token).unwrap_or(0);
+        let limit = pagination.page_size as i64;
+
+        let mut query_str = String::from(
+            "SELECT run_id, user_id, state, workflow_type, workflow_type_version, \
+            workflow_url, workflow_engine, workflow_engine_version, \
+            workflow_params, workflow_engine_parameters, tags, \
+            start_time, end_time, created_at FROM runs WHERE 1=1",
+        );
+
+        let mut bind_idx = 1;
+
+        if filter.state.is_some() {
+            query_str.push_str(&format!(" AND state = ${}", bind_idx));
+            bind_idx += 1;
+        }
+        if filter.user_id.is_some() {
+            query_str.push_str(&format!(" AND user_id = ${}", bind_idx));
+            bind_idx += 1;
+        }
+        if filter.started_after.is_some() {
+            query_str.push_str(&format!(" AND start_time >= ${}", bind_idx));
+            bind_idx += 1;
+        }
+        if filter.started_before.is_some() {
+            query_str.push_str(&format!(" AND start_time <= ${}", bind_idx));
+            bind_idx += 1;
+        }
+        if filter.tag_key.is_some() && filter.tag_value.is_some() {
+            query_str.push_str(&format!(" AND tags->>${} = ${}", bind_idx, bind_idx + 1));
+            bind_idx += 2;
+        } else if filter.tag_key.is_some() {
+            query_str.push_str(&format!(" AND tags ? ${}", bind_idx));
+            bind_idx += 1;
+        }
+
+        query_str
+            .push_str(&format!(" ORDER BY created_at DESC LIMIT ${} OFFSET {}", bind_idx, offset));
+
+        let mut query = sqlx::query(&query_str);
+
+        if let Some(ref state) = filter.state {
+            query = query.bind(state.to_string());
+        }
+        if let Some(ref user_id) = filter.user_id {
+            query = query.bind(user_id);
+        }
+        if let Some(ref started_after) = filter.started_after {
+            query = query.bind(started_after);
+        }
+        if let Some(ref started_before) = filter.started_before {
+            query = query.bind(started_before);
+        }
+        if let (Some(tag_key), Some(tag_value)) = (&filter.tag_key, &filter.tag_value) {
+            query = query.bind(tag_key).bind(tag_value);
+        } else if let Some(tag_key) = &filter.tag_key {
+            query = query.bind(tag_key);
+        }
+
+        query = query.bind(limit + 1);
+
+        let rows = query.fetch_all(&self.pool).await?;
+
+        let runs: Vec<Run> = rows.into_iter().map(map_row_to_run).collect();
+
+        let has_more = runs.len() > pagination.page_size as usize;
+        let items: Vec<Run> = runs.into_iter().take(pagination.page_size as usize).collect();
+
+        let next_page_token = if has_more {
+            Some(encode_offset(offset + pagination.page_size as u64))
+        } else {
+            None
+        };
+
+        Ok(PaginatedResult { items, next_page_token })
+    }
+
+    async fn count_by_state(&self) -> RepositoryResult<HashMap<String, i64>> {
+        let rows = sqlx::query("SELECT state, COUNT(*) as count FROM runs GROUP BY state")
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.get::<String, _>("state"), r.get::<i64, _>("count")))
+            .collect())
+    }
+}
+
+fn map_row_to_run(row: sqlx::postgres::PgRow) -> Run {
+    Run {
+        id: RunId::new(row.get::<String, _>("run_id")),
+        user_id: row.get::<String, _>("user_id"),
+        state: row.get::<String, _>("state").parse().unwrap_or(State::Unknown),
+        workflow_type: row.get("workflow_type"),
+        workflow_type_version: row.get("workflow_type_version"),
+        workflow_url: row.get("workflow_url"),
+        workflow_engine: row.get("workflow_engine"),
+        workflow_engine_version: row.get("workflow_engine_version"),
+        workflow_params: row.get("workflow_params"),
+        workflow_engine_parameters: row.get("workflow_engine_parameters"),
+        tags: row
+            .get::<Option<serde_json::Value>, _>("tags")
+            .unwrap_or_else(|| serde_json::Value::Object(Default::default())),
+        start_time: row.get("start_time"),
+        end_time: row.get("end_time"),
+        created_at: row.get("created_at"),
+    }
+}
+
+fn decode_offset(token: &Option<String>) -> Option<u64> {
+    token.as_ref().and_then(|t| {
+        let decoded = base64::engine::general_purpose::STANDARD.decode(t).ok()?;
+        String::from_utf8(decoded).ok()?.parse().ok()
+    })
+}
+
+fn encode_offset(offset: u64) -> String {
+    base64::engine::general_purpose::STANDARD.encode(offset.to_string())
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RunFilter {
+    pub state: Option<State>,
+    pub user_id: Option<String>,
+    pub tag_key: Option<String>,
+    pub tag_value: Option<String>,
+    pub started_after: Option<DateTime<Utc>>,
+    pub started_before: Option<DateTime<Utc>>,
+}
+
+impl RunFilter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Pagination {
+    pub page_size: u32,
+    pub page_token: Option<String>,
+}
+
+impl Pagination {
+    pub fn new(page_size: u32, page_token: Option<String>) -> Self {
+        Self { page_size, page_token }
+    }
+}
+
+impl Default for Pagination {
+    fn default() -> Self {
+        Self { page_size: 50, page_token: None }
+    }
+}
+
+#[derive(Debug)]
+pub struct PaginatedResult<T> {
+    pub items: Vec<T>,
+    pub next_page_token: Option<String>,
+}

--- a/crates/api/src/repositories/schema.rs
+++ b/crates/api/src/repositories/schema.rs
@@ -1,0 +1,151 @@
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(transparent)]
+#[schema(example = "550e8400-e29b-41d4-a716-446655440000")]
+pub struct RunId(String);
+
+impl RunId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for RunId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for RunId {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<&str> for RunId {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(transparent)]
+#[schema(example = "task_550e8400-e29b-41d4-a716-446655440001")]
+pub struct TaskId(String);
+
+impl TaskId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for TaskId {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<&str> for TaskId {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+pub use common::models::State;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Run {
+    pub id: RunId,
+    pub user_id: String,
+    pub state: State,
+    pub workflow_type: String,
+    pub workflow_type_version: String,
+    pub workflow_url: String,
+    pub workflow_engine: Option<String>,
+    pub workflow_engine_version: Option<String>,
+    pub workflow_params: Option<serde_json::Value>,
+    pub workflow_engine_parameters: Option<serde_json::Value>,
+    pub tags: serde_json::Value,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Task {
+    pub id: TaskId,
+    pub run_id: RunId,
+    pub name: String,
+    pub cmd: Option<Vec<String>>,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+    pub exit_code: Option<i32>,
+    pub system_logs: Option<Vec<String>>,
+    pub tes_uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LogLine {
+    pub run_id: RunId,
+    pub stream: LogStream,
+    pub seq: i64,
+    pub line: String,
+    pub written_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LogStream {
+    Stdout,
+    Stderr,
+}
+
+impl std::fmt::Display for LogStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogStream::Stdout => write!(f, "stdout"),
+            LogStream::Stderr => write!(f, "stderr"),
+        }
+    }
+}
+
+impl std::str::FromStr for LogStream {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "stdout" => Ok(LogStream::Stdout),
+            "stderr" => Ok(LogStream::Stderr),
+            _ => Err(format!("Invalid log stream: {}", s)),
+        }
+    }
+}

--- a/crates/api/src/repositories/task.rs
+++ b/crates/api/src/repositories/task.rs
@@ -1,0 +1,116 @@
+use async_trait::async_trait;
+use base64::Engine;
+use sqlx::{PgPool, Row};
+
+use super::{PaginatedResult, Pagination, RepositoryResult, RunId, Task, TaskId};
+
+#[async_trait]
+pub trait TaskRepository: Send + Sync {
+    async fn find_by_id(&self, run_id: &RunId, task_id: &TaskId) -> RepositoryResult<Option<Task>>;
+    async fn find_by_run(
+        &self,
+        run_id: &RunId,
+        pagination: Pagination,
+    ) -> RepositoryResult<PaginatedResult<Task>>;
+}
+
+pub struct SqlxTaskRepository {
+    pool: PgPool,
+}
+
+impl SqlxTaskRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl TaskRepository for SqlxTaskRepository {
+    async fn find_by_id(&self, run_id: &RunId, task_id: &TaskId) -> RepositoryResult<Option<Task>> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                task_id, run_id, name, cmd, start_time, end_time,
+                stdout, stderr, exit_code, system_logs, tes_uri
+            FROM task_logs
+            WHERE run_id = $1 AND task_id = $2
+            "#,
+        )
+        .bind(run_id.as_str())
+        .bind(task_id.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(map_row_to_task))
+    }
+
+    async fn find_by_run(
+        &self,
+        run_id: &RunId,
+        pagination: Pagination,
+    ) -> RepositoryResult<PaginatedResult<Task>> {
+        let offset = decode_offset(&pagination.page_token).unwrap_or(0);
+        let limit = pagination.page_size as i64;
+
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                task_id, run_id, name, cmd, start_time, end_time,
+                stdout, stderr, exit_code, system_logs, tes_uri
+            FROM task_logs
+            WHERE run_id = $1
+            ORDER BY id
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(run_id.as_str())
+        .bind(limit + 1)
+        .bind(offset as i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let tasks: Vec<Task> = rows.into_iter().map(map_row_to_task).collect();
+
+        let has_more = tasks.len() > pagination.page_size as usize;
+        let items: Vec<Task> = tasks.into_iter().take(pagination.page_size as usize).collect();
+
+        let next_page_token = if has_more {
+            Some(encode_offset(offset + pagination.page_size as u64))
+        } else {
+            None
+        };
+
+        Ok(PaginatedResult { items, next_page_token })
+    }
+}
+
+fn map_row_to_task(row: sqlx::postgres::PgRow) -> Task {
+    Task {
+        id: TaskId::new(row.get::<String, _>("task_id")),
+        run_id: RunId::new(row.get::<String, _>("run_id")),
+        name: row.get::<Option<String>, _>("name").unwrap_or_default(),
+        cmd: row
+            .get::<Option<serde_json::Value>, _>("cmd")
+            .and_then(|v| serde_json::from_value(v).ok()),
+        start_time: row.get("start_time"),
+        end_time: row.get("end_time"),
+        stdout: row.get("stdout"),
+        stderr: row.get("stderr"),
+        exit_code: row.get("exit_code"),
+        system_logs: row
+            .get::<Option<serde_json::Value>, _>("system_logs")
+            .and_then(|v| serde_json::from_value(v).ok()),
+        tes_uri: row.get("tes_uri"),
+    }
+}
+
+fn decode_offset(token: &Option<String>) -> Option<u64> {
+    token.as_ref().and_then(|t| {
+        let decoded = base64::engine::general_purpose::STANDARD.decode(t).ok()?;
+        String::from_utf8(decoded).ok()?.parse().ok()
+    })
+}
+
+fn encode_offset(offset: u64) -> String {
+    base64::engine::general_purpose::STANDARD.encode(offset.to_string())
+}

--- a/crates/api/src/repositories/task.rs
+++ b/crates/api/src/repositories/task.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
-use base64::Engine;
 use sqlx::{PgPool, Row};
 
-use super::{PaginatedResult, Pagination, RepositoryResult, RunId, Task, TaskId};
+use super::{
+    PaginatedResult, Pagination, RepositoryResult, RunId, Task, TaskId, calculate_next_token,
+    pagination_offset,
+};
 
 #[async_trait]
 pub trait TaskRepository: Send + Sync {
@@ -49,7 +51,7 @@ impl TaskRepository for SqlxTaskRepository {
         run_id: &RunId,
         pagination: Pagination,
     ) -> RepositoryResult<PaginatedResult<Task>> {
-        let offset = decode_offset(&pagination.page_token).unwrap_or(0);
+        let offset = pagination_offset(&pagination);
         let limit = pagination.page_size as i64;
 
         let rows = sqlx::query(
@@ -71,16 +73,7 @@ impl TaskRepository for SqlxTaskRepository {
 
         let tasks: Vec<Task> = rows.into_iter().map(map_row_to_task).collect();
 
-        let has_more = tasks.len() > pagination.page_size as usize;
-        let items: Vec<Task> = tasks.into_iter().take(pagination.page_size as usize).collect();
-
-        let next_page_token = if has_more {
-            Some(encode_offset(offset + pagination.page_size as u64))
-        } else {
-            None
-        };
-
-        Ok(PaginatedResult { items, next_page_token })
+        Ok(calculate_next_token(tasks, pagination.page_size, offset))
     }
 }
 
@@ -102,15 +95,4 @@ fn map_row_to_task(row: sqlx::postgres::PgRow) -> Task {
             .and_then(|v| serde_json::from_value(v).ok()),
         tes_uri: row.get("tes_uri"),
     }
-}
-
-fn decode_offset(token: &Option<String>) -> Option<u64> {
-    token.as_ref().and_then(|t| {
-        let decoded = base64::engine::general_purpose::STANDARD.decode(t).ok()?;
-        String::from_utf8(decoded).ok()?.parse().ok()
-    })
-}
-
-fn encode_offset(offset: u64) -> String {
-    base64::engine::general_purpose::STANDARD.encode(offset.to_string())
 }

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -1,0 +1,23 @@
+use axum::Router;
+use axum::routing::get;
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+
+use crate::api::{
+    get_run_log, get_run_status, get_task, list_log_lines, list_runs, list_tasks, stream_log_lines,
+};
+use crate::state::AppState;
+
+pub fn get_router(app_state: AppState) -> Router {
+    Router::new()
+        .route("/runs", get(list_runs))
+        .route("/runs/{run_id}", get(get_run_log))
+        .route("/runs/{run_id}/status", get(get_run_status))
+        .route("/runs/{run_id}/tasks", get(list_tasks))
+        .route("/runs/{run_id}/tasks/{task_id}", get(get_task))
+        .route("/runs/{run_id}/logs", get(list_log_lines))
+        .route("/runs/{run_id}/logs/stream", get(stream_log_lines))
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+        .with_state(app_state)
+}

--- a/crates/api/src/services/error.rs
+++ b/crates/api/src/services/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+use crate::repositories::RepositoryError;
+
+pub type ServiceResult<T> = std::result::Result<T, ServiceError>;
+
+#[derive(Debug, Error)]
+pub enum ServiceError {
+    #[error("Run not found: {0}")]
+    RunNotFound(String),
+
+    #[error("Task not found: {0}")]
+    TaskNotFound(String),
+
+    #[error("Invalid filter: {0}")]
+    InvalidFilter(String),
+
+    #[error(transparent)]
+    Repository(#[from] RepositoryError),
+}

--- a/crates/api/src/services/log.rs
+++ b/crates/api/src/services/log.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use super::ServiceResult;
+use crate::repositories::{LogLine, LogRepository, LogStream, PaginatedResult, RunId};
+
+#[derive(Clone)]
+pub struct LogService {
+    repo: Arc<dyn LogRepository>,
+}
+
+impl LogService {
+    pub fn new(repo: Arc<dyn LogRepository>) -> Self {
+        Self { repo }
+    }
+
+    pub async fn find_lines(
+        &self,
+        run_id: &RunId,
+        stream: Option<LogStream>,
+        after_seq: Option<i64>,
+        page_size: u32,
+    ) -> ServiceResult<PaginatedResult<LogLine>> {
+        self.repo
+            .find_lines(run_id, stream, after_seq, page_size)
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/crates/api/src/services/mod.rs
+++ b/crates/api/src/services/mod.rs
@@ -1,0 +1,9 @@
+mod error;
+mod log;
+mod run;
+mod task;
+
+pub use error::{ServiceError, ServiceResult};
+pub use log::LogService;
+pub use run::RunService;
+pub use task::TaskService;

--- a/crates/api/src/services/run.rs
+++ b/crates/api/src/services/run.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use super::ServiceResult;
+use crate::repositories::{PaginatedResult, Pagination, Run, RunFilter, RunId, RunRepository};
+
+#[derive(Clone)]
+pub struct RunService {
+    repo: Arc<dyn RunRepository>,
+}
+
+impl RunService {
+    pub fn new(repo: Arc<dyn RunRepository>) -> Self {
+        Self { repo }
+    }
+
+    pub async fn find_by_id(&self, id: &RunId) -> ServiceResult<Option<Run>> {
+        self.repo.find_by_id(id).await.map_err(Into::into)
+    }
+
+    pub async fn find_all(
+        &self,
+        filter: RunFilter,
+        pagination: Pagination,
+    ) -> ServiceResult<PaginatedResult<Run>> {
+        self.repo.find_all(filter, pagination).await.map_err(Into::into)
+    }
+}

--- a/crates/api/src/services/task.rs
+++ b/crates/api/src/services/task.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use super::ServiceResult;
+use crate::repositories::{PaginatedResult, Pagination, RunId, Task, TaskId, TaskRepository};
+
+#[derive(Clone)]
+pub struct TaskService {
+    repo: Arc<dyn TaskRepository>,
+}
+
+impl TaskService {
+    pub fn new(repo: Arc<dyn TaskRepository>) -> Self {
+        Self { repo }
+    }
+
+    pub async fn find_by_id(
+        &self,
+        run_id: &RunId,
+        task_id: &TaskId,
+    ) -> ServiceResult<Option<Task>> {
+        self.repo.find_by_id(run_id, task_id).await.map_err(Into::into)
+    }
+
+    pub async fn find_by_run(
+        &self,
+        run_id: &RunId,
+        pagination: Pagination,
+    ) -> ServiceResult<PaginatedResult<Task>> {
+        self.repo.find_by_run(run_id, pagination).await.map_err(Into::into)
+    }
+}

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use tokio::sync::RwLock;
+
+use crate::config::Config;
+use crate::infrastructure::Database;
+use crate::repositories::{
+    RepositoryError, SqlxLogRepository, SqlxRunRepository, SqlxTaskRepository,
+};
+use crate::services::{LogService, RunService, TaskService};
+
+#[derive(Clone)]
+pub struct Services {
+    pub runs: RunService,
+    pub tasks: TaskService,
+    pub logs: LogService,
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Database,
+    pub services: Services,
+    pub config: Config,
+    pub boot_time: Arc<RwLock<Option<DateTime<Utc>>>>,
+}
+
+impl AppState {
+    pub async fn new(config: &Config) -> Result<Self, RepositoryError> {
+        let db = Database::connect(&config.database_url).await?;
+        let pool = db.pool().clone();
+
+        let run_repo = Arc::new(SqlxRunRepository::new(pool.clone()));
+        let task_repo = Arc::new(SqlxTaskRepository::new(pool.clone()));
+        let log_repo = Arc::new(SqlxLogRepository::new(pool));
+
+        let services = Services {
+            runs: RunService::new(run_repo),
+            tasks: TaskService::new(task_repo),
+            logs: LogService::new(log_repo),
+        };
+
+        Ok(Self {
+            db,
+            services,
+            config: config.clone(),
+            boot_time: Arc::new(RwLock::new(None)),
+        })
+    }
+}

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -622,6 +622,45 @@ pub enum State {
     Preempted,
 }
 
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            State::Unknown => write!(f, "UNKNOWN"),
+            State::Queued => write!(f, "QUEUED"),
+            State::Initializing => write!(f, "INITIALIZING"),
+            State::Running => write!(f, "RUNNING"),
+            State::Paused => write!(f, "PAUSED"),
+            State::Complete => write!(f, "COMPLETE"),
+            State::ExecutorError => write!(f, "EXECUTOR_ERROR"),
+            State::SystemError => write!(f, "SYSTEM_ERROR"),
+            State::Canceled => write!(f, "CANCELED"),
+            State::Canceling => write!(f, "CANCELING"),
+            State::Preempted => write!(f, "PREEMPTED"),
+        }
+    }
+}
+
+impl std::str::FromStr for State {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "UNKNOWN" => Ok(State::Unknown),
+            "QUEUED" => Ok(State::Queued),
+            "INITIALIZING" => Ok(State::Initializing),
+            "RUNNING" => Ok(State::Running),
+            "PAUSED" => Ok(State::Paused),
+            "COMPLETE" => Ok(State::Complete),
+            "EXECUTOR_ERROR" => Ok(State::ExecutorError),
+            "SYSTEM_ERROR" => Ok(State::SystemError),
+            "CANCELED" => Ok(State::Canceled),
+            "CANCELING" => Ok(State::Canceling),
+            "PREEMPTED" => Ok(State::Preempted),
+            _ => Err(format!("Invalid state: {}", s)),
+        }
+    }
+}
+
 // Implement sqlx::Type for State to enable database storage
 impl sqlx::Type<sqlx::Postgres> for State {
     fn type_info() -> sqlx::postgres::PgTypeInfo {
@@ -671,6 +710,27 @@ impl sqlx::Decode<'_, sqlx::Postgres> for State {
             _ => Ok(State::Unknown),
         }
     }
+}
+
+/// State information of a workflow run.
+///
+/// # Example
+/// ```json
+/// {
+///   "run_id": "550e8400-e29b-41d4-a716-446655440000",
+///   "state": "RUNNING"
+/// }
+/// ```
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct RunStatus {
+    /// Unique identifier for the workflow run
+    #[serde(rename = "run_id")]
+    #[schema(example = "550e8400-e29b-41d4-a716-446655440000")]
+    pub run_id: String,
+
+    /// Current state of the workflow run
+    #[serde(rename = "state", skip_serializing_if = "Option::is_none")]
+    pub state: Option<State>,
 }
 
 /// The service will return a TaskListResponse when receiving a successful


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Introduce a new HTTP API service crate for querying workflow runs, tasks, and logs backed by the existing Postgres store.

New Features:
- Add a dedicated metis-api crate exposing REST endpoints to list runs, fetch run status and logs, and retrieve task details and logs, including log streaming via SSE.
- Introduce repository and service layers for runs, tasks, and log lines using sqlx and Postgres with pagination and filtering support.
- Expose an OpenAPI/Swagger UI documentation endpoint for the new API.
- Add a RunStatus response model and string serialization/parsing for workflow State in the common models crate.

Enhancements:
- Extend the workspace to include the new API crate and centralize shared configuration, error handling, and pagination/filter extractors for the HTTP layer.

Build:
- Register the new api crate as a workspace member and adjust OpenAPI-related dependencies.

Documentation:
- Generate OpenAPI schemas for runs, tasks, and logs and serve interactive API documentation via Swagger UI.