### PR TITLE
feat: add delete endpoint

### DIFF
--- a/app/css/theme.css
+++ b/app/css/theme.css
@@ -144,6 +144,22 @@ body {
   font-size: 0.78rem;
 }
 
+.btn-delete {
+  background: transparent;
+  color: var(--text-light);
+  border-color: var(--border);
+}
+.btn-delete:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--status-error) 8%, transparent);
+  color: var(--status-error);
+  border-color: color-mix(in srgb, var(--status-error) 40%, transparent);
+}
+
+.btn-delete-sm {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+}
+
 .btn:disabled {
   opacity: 0.38;
   cursor: not-allowed;
@@ -235,6 +251,15 @@ body {
   width: 1%;
   white-space: nowrap;
   text-align: right;
+}
+
+.col-action .btn + .btn {
+  margin-left: 0.35rem;
+}
+
+.run-actions {
+  display: flex;
+  gap: 0.5rem;
 }
 
 /* ── Status badges ───────────────────────────────────────────────────────── */

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -5,6 +5,13 @@ let logsPaused = false;
 let _nextPageToken = null;
 
 const CANCELABLE_STATES = new Set(["QUEUED", "INITIALIZING", "RUNNING", "PAUSED"]);
+const DELETABLE_STATES = new Set([
+  "COMPLETE",
+  "EXECUTOR_ERROR",
+  "SYSTEM_ERROR",
+  "CANCELED",
+  "PREEMPTED",
+]);
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -73,13 +80,22 @@ function renderRunsList(data) {
     .map((run) => {
       const state = run.state || "UNKNOWN";
       const canCancel = CANCELABLE_STATES.has(state);
+      const canDelete = DELETABLE_STATES.has(state);
       const safeId = escapeAttr(run.run_id);
+
       const cancelBtn = canCancel
         ? `<button
             class="btn btn-danger btn-danger-sm"
             onclick="event.stopPropagation(); cancelRunById('${safeId}', this)"
-            title="Cancel run">Cancel</button>`
-        : `<button class="btn btn-danger btn-danger-sm" disabled title="Cannot cancel">Cancel</button>`;
+            title="Cancel the running workflow">Cancel</button>`
+        : "";
+
+      const deleteBtn = canDelete
+        ? `<button
+            class="btn btn-delete btn-delete-sm"
+            onclick="event.stopPropagation(); deleteRunById('${safeId}', this)"
+            title="Permanently delete this run from the database">Delete</button>`
+        : "";
 
       return `
         <tr data-state="${state}" onclick="window.location.href='/run.html?run_id=${encodeURIComponent(run.run_id)}'">
@@ -87,7 +103,7 @@ function renderRunsList(data) {
           <td><span class="status-badge ${getStatusClass(state)}">${state}</span></td>
           <td>${formatRelativeTime(run.start_time)}</td>
           <td>${run.end_time ? formatRelativeTime(run.end_time) : "-"}</td>
-          <td class="col-action">${cancelBtn}</td>
+          <td class="col-action">${cancelBtn}${deleteBtn}</td>
         </tr>`;
     })
     .join("");
@@ -96,7 +112,6 @@ function renderRunsList(data) {
 }
 
 async function _cancelRunById(runId, btn) {
-  if (!confirm(`Cancel run ${runId}?\nThis cannot be undone.`)) return;
   btn.disabled = true;
   btn.textContent = "…";
   try {
@@ -119,6 +134,55 @@ async function _cancelRunById(runId, btn) {
   }
 }
 
+async function _deleteRunById(runId, btn) {
+  btn.disabled = true;
+  btn.textContent = "…";
+  try {
+    const res = await fetch(`${API_BASE}/runs/${encodeURIComponent(runId)}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert(`Delete failed: ${err.msg || res.status}`);
+      btn.disabled = false;
+      btn.textContent = "Delete";
+      return;
+    }
+    setTimeout(() => htmx.trigger("#runs-body", "load"), 300);
+  } catch (err) {
+    alert(`Delete failed: ${err.message}`);
+    btn.disabled = false;
+    btn.textContent = "Delete";
+  }
+}
+
+async function _deleteRun() {
+  const btn = document.getElementById("delete-btn");
+  if (!btn || !currentRunId) return;
+
+  btn.disabled = true;
+  btn.textContent = "Deleting…";
+
+  try {
+    const res = await fetch(`${API_BASE}/runs/${encodeURIComponent(currentRunId)}`, {
+      method: "DELETE",
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert(`Delete failed: ${err.msg || res.status}`);
+      btn.disabled = false;
+      btn.textContent = "Delete Run";
+      return;
+    }
+
+    window.location.href = "/";
+  } catch (err) {
+    alert(`Delete failed: ${err.message}`);
+    btn.disabled = false;
+    btn.textContent = "Delete Run";
+  }
+}
 // ── Run detail ────────────────────────────────────────────────────────────
 
 async function _loadRun(runId) {
@@ -145,27 +209,20 @@ async function _loadRun(runId) {
 function renderRunHeader(run) {
   const state = run.state || "UNKNOWN";
   const canCancel = CANCELABLE_STATES.has(state);
+  const canDelete = DELETABLE_STATES.has(state);
+
+  const cancelBtn = canCancel
+    ? `<button type="button" class="btn btn-danger" id="cancel-btn" onclick="cancelRun()">Cancel Run</button>`
+    : "";
+
+  const deleteBtn = canDelete
+    ? `<button type="button" class="btn btn-delete" id="delete-btn" onclick="deleteRun()">Delete Run</button>`
+    : "";
+
   document.getElementById("run-header").innerHTML = `
     <div class="run-header-top">
       <span class="status-badge ${getStatusClass(state)}">${state}</span>
-      <button type="button" class="btn btn-danger" id="cancel-btn"
-        onclick="cancelRun()" ${canCancel ? "" : "disabled"}>
-        Cancel Run
-      </button>
-    </div>
-    <div class="run-info">
-      <div class="run-info-item">
-        <label>Started</label>
-        <span>${formatTimestamp(run.request?.start_time)}</span>
-      </div>
-      <div class="run-info-item">
-        <label>Workflow URL</label>
-        <span>${truncate(run.request?.workflow_url, 50)}</span>
-      </div>
-      <div class="run-info-item">
-        <label>Workflow Type</label>
-        <span>${escapeHtml(run.request?.workflow_type || "-")} ${escapeHtml(run.request?.workflow_type_version || "")}</span>
-      </div>
+      <div class="run-actions">${cancelBtn}${deleteBtn}</div>
     </div>`;
 }
 
@@ -333,5 +390,7 @@ document.body.addEventListener("htmx:beforeSwap", (evt) => {
 window.loadRun = _loadRun;
 window.cancelRun = _cancelRun;
 window.cancelRunById = _cancelRunById;
+window.deleteRun = _deleteRun;
+window.deleteRunById = _deleteRunById;
 window.showTab = _showTab;
 window.toggleLogs = _toggleLogs;

--- a/crates/api/src/api/runs.rs
+++ b/crates/api/src/api/runs.rs
@@ -185,3 +185,28 @@ pub async fn cancel_run(
 
     Ok(Json(serde_json::json!({ "status": "cancel requested" })))
 }
+
+#[utoipa::path(
+    delete,
+    path = "/runs/{run_id}",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID")
+    ),
+    responses(
+        (status = 200, description = "Run deleted", body = RunIdModel),
+        (status = 400, description = "Run cannot be deleted in current state"),
+        (status = 404, description = "Run not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn delete_run(
+    State(app): State<AppState>,
+    Path(run_id): Path<String>,
+) -> ApiResult<Json<RunIdModel>> {
+    let id = RunId::new(run_id);
+
+    app.services.runs.delete_run(&id).await?;
+
+    Ok(Json(RunIdModel { run_id: Some(id.into_inner()) }))
+}

--- a/crates/api/src/docs.rs
+++ b/crates/api/src/docs.rs
@@ -13,6 +13,7 @@ use crate::api::logs::{LogLineListResponse, LogLineResponse};
         crate::api::runs::get_run_log,
         crate::api::runs::get_run_status,
         crate::api::runs::cancel_run,
+        crate::api::runs::delete_run,
         crate::api::tasks::list_tasks,
         crate::api::tasks::get_task,
         crate::api::logs::list_log_lines,

--- a/crates/api/src/repositories/run.rs
+++ b/crates/api/src/repositories/run.rs
@@ -31,6 +31,7 @@ pub trait RunRepository: Send + Sync {
     ) -> RepositoryResult<bool>;
     async fn find_active_runs(&self) -> RepositoryResult<Vec<Run>>;
     async fn finalize_orphaned_run(&self, id: &RunId, state: State) -> RepositoryResult<()>;
+    async fn soft_delete(&self, id: &RunId) -> RepositoryResult<bool>;
 }
 
 pub struct SqlxRunRepository {
@@ -52,9 +53,9 @@ impl RunRepository for SqlxRunRepository {
                 run_id, user_id, state, workflow_type, workflow_type_version,
                 workflow_url, workflow_engine, workflow_engine_version,
                 workflow_params, workflow_engine_parameters, tags,
-                start_time, end_time, created_at
+                start_time, end_time, created_at, deleted_at
             FROM runs
-            WHERE run_id = $1
+            WHERE run_id = $1 AND deleted_at IS NULL
             "#,
         )
         .bind(id.as_str())
@@ -76,7 +77,7 @@ impl RunRepository for SqlxRunRepository {
             "SELECT run_id, user_id, state, workflow_type, workflow_type_version, \
             workflow_url, workflow_engine, workflow_engine_version, \
             workflow_params, workflow_engine_parameters, tags, \
-            start_time, end_time, created_at FROM runs WHERE 1=1",
+            start_time, end_time, created_at, deleted_at FROM runs WHERE deleted_at IS NULL",
         );
 
         let mut bind_idx = 1;
@@ -138,9 +139,11 @@ impl RunRepository for SqlxRunRepository {
     }
 
     async fn count_by_state(&self) -> RepositoryResult<HashMap<String, i64>> {
-        let rows = sqlx::query("SELECT state, COUNT(*) as count FROM runs GROUP BY state")
-            .fetch_all(&self.pool)
-            .await?;
+        let rows = sqlx::query(
+            "SELECT state, COUNT(*) as count FROM runs WHERE deleted_at IS NULL GROUP BY state",
+        )
+        .fetch_all(&self.pool)
+        .await?;
 
         Ok(rows
             .into_iter()
@@ -221,9 +224,9 @@ impl RunRepository for SqlxRunRepository {
             SELECT run_id, user_id, state, workflow_type, workflow_type_version,
                 workflow_url, workflow_engine, workflow_engine_version,
                 workflow_params, workflow_engine_parameters, tags,
-                start_time, end_time, created_at
+                start_time, end_time, created_at, deleted_at
             FROM runs
-            WHERE state IN ('RUNNING', 'INITIALIZING')
+            WHERE state IN ('RUNNING', 'INITIALIZING') AND deleted_at IS NULL
             "#,
         )
         .fetch_all(&self.pool)
@@ -239,6 +242,16 @@ impl RunRepository for SqlxRunRepository {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+
+    async fn soft_delete(&self, id: &RunId) -> RepositoryResult<bool> {
+        let result = sqlx::query(
+            "UPDATE runs SET deleted_at = NOW() WHERE run_id = $1 AND deleted_at IS NULL",
+        )
+        .bind(id.as_str())
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
     }
 }
 
@@ -260,6 +273,7 @@ fn map_row_to_run(row: sqlx::postgres::PgRow) -> Run {
         start_time: row.get("start_time"),
         end_time: row.get("end_time"),
         created_at: row.get("created_at"),
+        deleted_at: row.get("deleted_at"),
     }
 }
 

--- a/crates/api/src/repositories/schema.rs
+++ b/crates/api/src/repositories/schema.rs
@@ -96,6 +96,7 @@ pub struct Run {
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -4,7 +4,7 @@ use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 
 use crate::api::{
-    cancel_run, create_run, get_run_log, get_run_status, get_service_info, get_task,
+    cancel_run, create_run, delete_run, get_run_log, get_run_status, get_service_info, get_task,
     list_log_lines, list_runs, list_tasks, stream_log_lines,
 };
 use crate::state::AppState;
@@ -13,7 +13,7 @@ pub fn get_router(app_state: AppState) -> Router {
     Router::new()
         .route("/service-info", get(get_service_info))
         .route("/runs", get(list_runs).post(create_run))
-        .route("/runs/{run_id}", get(get_run_log))
+        .route("/runs/{run_id}", get(get_run_log).delete(delete_run))
         .route("/runs/{run_id}/cancel", post(cancel_run))
         .route("/runs/{run_id}/status", get(get_run_status))
         .route("/runs/{run_id}/tasks", get(list_tasks))

--- a/crates/api/src/services/run.rs
+++ b/crates/api/src/services/run.rs
@@ -126,6 +126,37 @@ impl RunService {
         self.repo.finalize_orphaned_run(id, state).await.map_err(Into::into)
     }
 
+    pub async fn delete_run(&self, id: &RunId) -> ServiceResult<()> {
+        let run = self
+            .repo
+            .find_by_id(id)
+            .await?
+            .ok_or_else(|| ServiceError::RunNotFound(id.to_string()))?;
+
+        match run.state {
+            State::Complete
+            | State::ExecutorError
+            | State::SystemError
+            | State::Canceled
+            | State::Preempted => {
+                let deleted = self.repo.soft_delete(id).await?;
+                if deleted {
+                    tracing::info!(
+                        run_id = %id,
+                        user_id = %run.user_id,
+                        state = %run.state,
+                        "Run soft deleted"
+                    );
+                }
+                Ok(())
+            },
+            _ => Err(ServiceError::InvalidState(format!(
+                "Cannot delete run in non-terminal state: {}",
+                run.state
+            ))),
+        }
+    }
+
     pub fn redis(&self) -> &Arc<RedisClient> {
         &self.redis
     }

--- a/migrations/000002_add_deleted_at.down.sql
+++ b/migrations/000002_add_deleted_at.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_runs_deleted_at;
+ALTER TABLE runs DROP COLUMN deleted_at;

--- a/migrations/000002_add_deleted_at.up.sql
+++ b/migrations/000002_add_deleted_at.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE runs ADD COLUMN deleted_at TIMESTAMPTZ;
+CREATE INDEX idx_runs_deleted_at ON runs (deleted_at) WHERE deleted_at IS NOT NULL;


### PR DESCRIPTION
Soft deletes the run

#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Introduce soft-delete support for runs and expose it via a new DELETE /runs/{run_id} API endpoint.

New Features:
- Add DELETE /runs/{run_id} endpoint to request deletion of a workflow run.
- Implement soft-delete behavior for runs, restricting deletion to terminal states.

Enhancements:
- Exclude soft-deleted runs from run lookup, listing, active-run queries, and state counting via repository and schema updates.
- Extend the run schema and database with a deleted_at column and supporting index, with corresponding up/down migrations.
- Add OpenAPI documentation wiring for the new delete run endpoint.