### PR TITLE
fix: use group pid to cancel child process

### DIFF
--- a/crates/engine/src/execution.rs
+++ b/crates/engine/src/execution.rs
@@ -132,8 +132,8 @@ impl ProcessExecutor {
 
             signal::kill(pgid, Signal::SIGTERM).map_err(|e| {
                 EngineError::Execution(format!(
-                    "Failed to send SIGTERM to process group {}: {}",
-                    pid, e
+                    "Failed to send SIGTERM to process group {} (original pid {}): {}",
+                    pgid, pid, e
                 ))
             })?;
 
@@ -143,16 +143,16 @@ impl ProcessExecutor {
                 Ok(_) => {
                     signal::kill(pgid, Signal::SIGKILL).map_err(|e| {
                         EngineError::Execution(format!(
-                            "Failed to send SIGKILL to process group {}: {}",
-                            pid, e
+                            "Failed to send SIGKILL to process group {} (original pid {}): {}",
+                            pgid, pid, e
                         ))
                     })?;
                 },
                 Err(Errno::ESRCH) => {
-                    info!(pid = %pid, "Process group has already exited");
+                    info!(pgid = %pgid, pid = %pid, "Process group has already exited");
                 },
                 Err(e) => {
-                    warn!(pid = %pid, error = %e, "Failed to check process group status before SIGKILL");
+                    warn!(pgid = %pgid, pid = %pid, error = %e, "Failed to check process group status before SIGKILL");
                 },
             }
         }

--- a/crates/engine/src/execution.rs
+++ b/crates/engine/src/execution.rs
@@ -37,6 +37,9 @@ impl ProcessExecutor {
             .stdin(std::process::Stdio::null())
             .kill_on_drop(true);
 
+        #[cfg(unix)]
+        cmd.process_group(0);
+
         let child = cmd.spawn().map_err(|e| {
             EngineError::Execution(format!("Failed to spawn workflow process: {}", e))
         })?;
@@ -123,28 +126,33 @@ impl ProcessExecutor {
             use nix::sys::signal::{self, Signal};
             use nix::unistd::Pid;
 
-            let pid = Pid::from_raw(pid as i32);
+            // Negate PID to target the entire process group (PGID = PID since
+            // we called process_group(0) at spawn time).
+            let pgid = Pid::from_raw(-(pid as i32));
 
-            signal::kill(pid, Signal::SIGTERM).map_err(|e| {
-                EngineError::Execution(format!("Failed to send SIGTERM to process {}: {}", pid, e))
+            signal::kill(pgid, Signal::SIGTERM).map_err(|e| {
+                EngineError::Execution(format!(
+                    "Failed to send SIGTERM to process group {}: {}",
+                    pid, e
+                ))
             })?;
 
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
-            match signal::kill(pid, None) {
+            match signal::kill(pgid, None) {
                 Ok(_) => {
-                    signal::kill(pid, Signal::SIGKILL).map_err(|e| {
+                    signal::kill(pgid, Signal::SIGKILL).map_err(|e| {
                         EngineError::Execution(format!(
-                            "Failed to send SIGKILL to process {}: {}",
+                            "Failed to send SIGKILL to process group {}: {}",
                             pid, e
                         ))
                     })?;
                 },
                 Err(Errno::ESRCH) => {
-                    info!(pid = %pid, "Process has already exited");
+                    info!(pid = %pid, "Process group has already exited");
                 },
                 Err(e) => {
-                    warn!(pid = %pid, error = %e, "Failed to check process status before SIGKILL");
+                    warn!(pid = %pid, error = %e, "Failed to check process group status before SIGKILL");
                 },
             }
         }


### PR DESCRIPTION
Previous behaviour only cancelled the
parent process, ie the shell command
which let the engine process keep running.

#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Bug Fixes:
- Send termination signals to the spawned process group so that all child processes are correctly cancelled on Unix platforms.