### PR TITLE
feat: stream run status

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -314,7 +314,6 @@ async function _loadRun(runId) {
     const run = await runRes.json();
     renderRunHeader(run);
     renderOverview(run);
-    renderTasks(tasks);
     connectStatusStream();
   } catch (err) {
     document.getElementById("overview-content").innerHTML =
@@ -579,7 +578,7 @@ function connectStatusStream() {
   statusEventSource.onmessage = (event) => {
     try {
       const data = JSON.parse(event.data);
-      const badge = document.querySelector(".status-badge");
+      const badge = document.getElementById("run-state-badge");
       if (badge) {
         badge.className = `status-badge ${getStatusClass(data.state)}`;
         badge.textContent = data.state;
@@ -587,7 +586,15 @@ function connectStatusStream() {
 
       if (DELETABLE_STATES.has(data.state)) {
         statusEventSource.close();
-        _loadRun(currentRunId);
+        statusEventSource = null;
+        renderRunHeader({ state: data.state });
+        // Refresh tasks once run reaches terminal state
+        fetch(`${API_BASE}/runs/${encodeURIComponent(currentRunId)}/tasks`)
+          .then((r) => (r.ok ? r.json() : null))
+          .then((tasks) => {
+            if (tasks) renderTasks(tasks);
+          })
+          .catch(() => {});
       }
     } catch (e) {
       console.error("Failed to parse status update:", e);
@@ -595,7 +602,10 @@ function connectStatusStream() {
   };
 
   statusEventSource.onerror = () => {
+    if (!statusEventSource || statusEventSource.readyState === EventSource.CLOSED) return;
     console.log("Status SSE connection lost, reconnecting...");
+    statusEventSource.close();
+    statusEventSource = null;
     setTimeout(connectStatusStream, 3000);
   };
 }

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,6 +1,7 @@
 const API_BASE = "/api";
 let currentRunId = null;
 let logsEventSource = null;
+let statusEventSource = null;
 let logsPaused = false;
 let _nextPageToken = null;
 
@@ -313,6 +314,8 @@ async function _loadRun(runId) {
     const run = await runRes.json();
     renderRunHeader(run);
     renderOverview(run);
+    renderTasks(tasks);
+    connectStatusStream();
   } catch (err) {
     document.getElementById("overview-content").innerHTML =
       `<div class="empty-state">Error: ${escapeHtml(err.message)}</div>`;
@@ -565,6 +568,35 @@ function connectLogs() {
   logsEventSource.onerror = () => {
     console.log("SSE connection lost, reconnecting...");
     setTimeout(connectLogs, 3000);
+  };
+}
+
+function connectStatusStream() {
+  if (statusEventSource) statusEventSource.close();
+  const url = `${API_BASE}/runs/${encodeURIComponent(currentRunId)}/status/stream`;
+  statusEventSource = new EventSource(url);
+
+  statusEventSource.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      const badge = document.querySelector(".status-badge");
+      if (badge) {
+        badge.className = `status-badge ${getStatusClass(data.state)}`;
+        badge.textContent = data.state;
+      }
+
+      if (DELETABLE_STATES.has(data.state)) {
+        statusEventSource.close();
+        _loadRun(currentRunId);
+      }
+    } catch (e) {
+      console.error("Failed to parse status update:", e);
+    }
+  };
+
+  statusEventSource.onerror = () => {
+    console.log("Status SSE connection lost, reconnecting...");
+    setTimeout(connectStatusStream, 3000);
   };
 }
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -570,7 +570,7 @@ function connectLogs() {
   };
 }
 
-function connectStatusStream() {
+function connectStatusStream(retries = 0) {
   if (statusEventSource) statusEventSource.close();
   const url = `${API_BASE}/runs/${encodeURIComponent(currentRunId)}/status/stream`;
   statusEventSource = new EventSource(url);
@@ -580,7 +580,11 @@ function connectStatusStream() {
       const data = JSON.parse(event.data);
       const badge = document.getElementById("run-state-badge");
       if (badge) {
-        badge.className = `status-badge ${getStatusClass(data.state)}`;
+        badge.classList.forEach((cls) => {
+          if (cls !== "status-badge" && cls.startsWith("status-")) badge.classList.remove(cls);
+        });
+        const sc = getStatusClass(data.state);
+        if (sc) badge.classList.add(sc);
         badge.textContent = data.state;
       }
 
@@ -603,10 +607,17 @@ function connectStatusStream() {
 
   statusEventSource.onerror = () => {
     if (!statusEventSource || statusEventSource.readyState === EventSource.CLOSED) return;
-    console.log("Status SSE connection lost, reconnecting...");
     statusEventSource.close();
     statusEventSource = null;
-    setTimeout(connectStatusStream, 3000);
+    if (retries >= 5) {
+      console.warn("Status SSE max retries reached, giving up.");
+      return;
+    }
+    const delay = Math.min(1000 * 2 ** retries, 30_000);
+    console.log(
+      `Status SSE connection lost, reconnecting in ${delay}ms (attempt ${retries + 1})...`
+    );
+    setTimeout(() => connectStatusStream(retries + 1), delay);
   };
 }
 

--- a/crates/api/src/api/runs.rs
+++ b/crates/api/src/api/runs.rs
@@ -155,10 +155,13 @@ pub async fn stream_run_status(
 
     tokio::spawn(async move {
         let mut last_state: Option<RunState> = None;
+        let poll_interval_ms: u64 = 1_000;
+        let mut error_backoff_ms: u64 = poll_interval_ms;
 
         loop {
             match app.services.runs.find_by_id(&id).await {
                 Ok(Some(run)) => {
+                    error_backoff_ms = poll_interval_ms;
                     let current_state = run.state;
 
                     if last_state != Some(current_state) {
@@ -194,10 +197,11 @@ pub async fn stream_run_status(
                 },
                 Err(e) => {
                     tracing::error!("Error fetching run status: {}", e);
+                    error_backoff_ms = error_backoff_ms.saturating_mul(2).min(30_000);
                 },
             }
 
-            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(error_backoff_ms)).await;
         }
     });
 

--- a/crates/api/src/api/runs.rs
+++ b/crates/api/src/api/runs.rs
@@ -1,6 +1,10 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use common::models::{RunId as RunIdModel, RunListResponse, RunLog, RunRequest, RunStatus};
+use axum::response::sse::{Event, Sse};
+use common::models::{
+    RunId as RunIdModel, RunListResponse, RunLog, RunRequest, RunStatus, State as RunState,
+};
+use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use crate::api::{ApiError, ApiResult};
@@ -126,6 +130,79 @@ pub async fn get_run_status(
         run_id: run.id.into_inner(),
         state: Some(run.state),
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/runs/{run_id}/status/stream",
+    tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Workflow run ID")
+    ),
+    responses(
+        (status = 200, description = "SSE stream of run status updates", content_type = "text/event-stream"),
+        (status = 404, description = "Run not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn stream_run_status(
+    State(app): State<AppState>,
+    Path(run_id): Path<String>,
+) -> ApiResult<Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>> {
+    let id = RunId::new(run_id.clone());
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(10);
+
+    tokio::spawn(async move {
+        let mut last_state: Option<RunState> = None;
+
+        loop {
+            match app.services.runs.find_by_id(&id).await {
+                Ok(Some(run)) => {
+                    let current_state = run.state;
+                    let state_changed = last_state != Some(current_state);
+
+                    if state_changed || last_state.is_none() {
+                        let status = RunStatus {
+                            run_id: run.id.into_inner(),
+                            state: Some(current_state),
+                        };
+
+                        let json = serde_json::to_string(&status).unwrap_or_default();
+                        let event = Event::default().data(json);
+
+                        if tx.send(Ok(event)).await.is_err() {
+                            return;
+                        }
+
+                        last_state = Some(current_state);
+                    }
+
+                    if matches!(
+                        current_state,
+                        RunState::Complete
+                            | RunState::ExecutorError
+                            | RunState::SystemError
+                            | RunState::Canceled
+                            | RunState::Preempted
+                    ) {
+                        return;
+                    }
+                },
+                Ok(None) => {
+                    tracing::error!("Run not found: {}", id);
+                    return;
+                },
+                Err(e) => {
+                    tracing::error!("Error fetching run status: {}", e);
+                },
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+    });
+
+    Ok(Sse::new(ReceiverStream::new(rx)))
 }
 
 #[utoipa::path(

--- a/crates/api/src/api/runs.rs
+++ b/crates/api/src/api/runs.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use axum::response::sse::{Event, Sse};
+use axum::response::sse::{Event, KeepAlive, Sse};
 use common::models::{
     RunId as RunIdModel, RunListResponse, RunLog, RunRequest, RunStatus, State as RunState,
 };
@@ -160,9 +160,8 @@ pub async fn stream_run_status(
             match app.services.runs.find_by_id(&id).await {
                 Ok(Some(run)) => {
                     let current_state = run.state;
-                    let state_changed = last_state != Some(current_state);
 
-                    if state_changed || last_state.is_none() {
+                    if last_state != Some(current_state) {
                         let status = RunStatus {
                             run_id: run.id.into_inner(),
                             state: Some(current_state),
@@ -202,7 +201,8 @@ pub async fn stream_run_status(
         }
     });
 
-    Ok(Sse::new(ReceiverStream::new(rx)))
+    Ok(Sse::new(ReceiverStream::new(rx))
+        .keep_alive(KeepAlive::new().interval(std::time::Duration::from_secs(15))))
 }
 
 #[utoipa::path(

--- a/crates/api/src/docs.rs
+++ b/crates/api/src/docs.rs
@@ -12,6 +12,7 @@ use crate::api::logs::{LogLineListResponse, LogLineResponse};
         crate::api::runs::create_run,
         crate::api::runs::get_run_log,
         crate::api::runs::get_run_status,
+        crate::api::runs::stream_run_status,
         crate::api::runs::cancel_run,
         crate::api::runs::delete_run,
         crate::api::tasks::list_tasks,

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -5,7 +5,7 @@ use tower_http::trace::TraceLayer;
 
 use crate::api::{
     cancel_run, create_run, delete_run, get_run_log, get_run_status, get_service_info, get_task,
-    list_log_lines, list_runs, list_tasks, stream_log_lines,
+    list_log_lines, list_runs, list_tasks, stream_log_lines, stream_run_status,
 };
 use crate::state::AppState;
 
@@ -16,6 +16,7 @@ pub fn get_router(app_state: AppState) -> Router {
         .route("/runs/{run_id}", get(get_run_log).delete(delete_run))
         .route("/runs/{run_id}/cancel", post(cancel_run))
         .route("/runs/{run_id}/status", get(get_run_status))
+        .route("/runs/{run_id}/status/stream", get(stream_run_status))
         .route("/runs/{run_id}/tasks", get(list_tasks))
         .route("/runs/{run_id}/tasks/{task_id}", get(get_task))
         .route("/runs/{run_id}/logs", get(list_log_lines))


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Add server-sent events streaming for workflow run status and wire it to the UI for live status updates.

New Features:
- Expose a new SSE endpoint to stream workflow run status changes until completion or terminal error.
- Hook the frontend to the new status stream to live-update the run status badge and refresh run details when the run reaches a terminal state.

Enhancements:
- Extend routing configuration to register the new status streaming endpoint.