### PR TITLE
feat: add healthz, readyz and startupz

### DIFF
--- a/crates/api/src/api/health.rs
+++ b/crates/api/src/api/health.rs
@@ -5,10 +5,16 @@ use serde_json::json;
 
 use crate::state::AppState;
 
+#[utoipa::path(get, path = "/healthz", tag = "Health",
+    responses((status = 200, description = "Service is alive"))
+)]
 pub async fn healthz() -> impl IntoResponse {
     (StatusCode::OK, serde_json::to_string(&json!({ "status": "ok" })).unwrap())
 }
 
+#[utoipa::path(get, path = "/readyz", tag = "Health",
+    responses((status = 200, description = "Service is ready"))
+)]
 pub async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
     let boot_time = state.boot_time.read().await;
     let boot_time_str = boot_time
@@ -26,6 +32,12 @@ pub async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
     )
 }
 
+#[utoipa::path(get, path = "/startupz", tag = "Health",
+    responses(
+        (status = 200, description = "All dependencies healthy"),
+        (status = 503, description = "One or more dependencies degraded"),
+    )
+)]
 pub async fn startupz(State(state): State<AppState>) -> impl IntoResponse {
     let redis_ok = state.services.runs.redis().health_check().await;
     let nats_ok = state.services.runs.nats().health_check().await;

--- a/crates/api/src/api/health.rs
+++ b/crates/api/src/api/health.rs
@@ -1,0 +1,53 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+use crate::state::AppState;
+
+pub async fn healthz() -> impl IntoResponse {
+    (StatusCode::OK, serde_json::to_string(&json!({ "status": "ok" })).unwrap())
+}
+
+pub async fn readyz(State(state): State<AppState>) -> impl IntoResponse {
+    let boot_time = state.boot_time.read().await;
+    let boot_time_str = boot_time
+        .as_ref()
+        .map(|t| t.to_rfc3339())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    (
+        StatusCode::OK,
+        serde_json::to_string(&json!({
+            "status": "ok",
+            "boot_time": boot_time_str
+        }))
+        .unwrap(),
+    )
+}
+
+pub async fn startupz(State(state): State<AppState>) -> impl IntoResponse {
+    let redis_ok = state.services.runs.redis().health_check().await;
+    let nats_ok = state.services.runs.nats().health_check().await;
+    let db_ok = state.db.health_check().await;
+
+    let all_healthy = redis_ok && nats_ok && db_ok;
+    let status = if all_healthy {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (
+        status,
+        serde_json::to_string(&json!({
+            "status": if all_healthy { "ok" } else { "degraded" },
+            "checks": {
+                "redis": if redis_ok { "ok" } else { "error" },
+                "nats": if nats_ok { "ok" } else { "error" },
+                "db": if db_ok { "ok" } else { "error" }
+            }
+        }))
+        .unwrap(),
+    )
+}

--- a/crates/api/src/api/mod.rs
+++ b/crates/api/src/api/mod.rs
@@ -1,10 +1,12 @@
 pub mod error;
+pub mod health;
 pub mod logs;
 pub mod runs;
 pub mod service_info;
 pub mod tasks;
 
 pub use error::{ApiError, ApiResult};
+pub use health::*;
 pub use logs::*;
 pub use runs::*;
 pub use service_info::*;

--- a/crates/api/src/docs.rs
+++ b/crates/api/src/docs.rs
@@ -19,6 +19,9 @@ use crate::api::logs::{LogLineListResponse, LogLineResponse};
         crate::api::tasks::get_task,
         crate::api::logs::list_log_lines,
         crate::api::logs::stream_log_lines,
+        crate::api::health::healthz,
+        crate::api::health::readyz,
+        crate::api::health::startupz,
     ),
     components(
         schemas(
@@ -52,6 +55,7 @@ use crate::api::logs::{LogLineListResponse, LogLineResponse};
         )
     ),
     tags(
+        (name = "Health", description = "Health check endpoints"),
         (name = "Service Info", description = "Service information endpoints"),
         (name = "Runs", description = "Workflow run management endpoints"),
     ),

--- a/crates/api/src/infrastructure/database.rs
+++ b/crates/api/src/infrastructure/database.rs
@@ -31,3 +31,9 @@ impl std::ops::Deref for Database {
         &self.pool
     }
 }
+
+impl Database {
+    pub async fn health_check(&self) -> bool {
+        sqlx::query("SELECT 1").fetch_one(&self.pool).await.is_ok()
+    }
+}

--- a/crates/api/src/infrastructure/nats.rs
+++ b/crates/api/src/infrastructure/nats.rs
@@ -41,4 +41,8 @@ impl NatsPublisher {
             .map_err(|e| format!("NATS publish error: {}", e))?;
         Ok(())
     }
+
+    pub async fn health_check(&self) -> bool {
+        matches!(self.client.connection_state(), async_nats::connection::State::Connected)
+    }
 }

--- a/crates/api/src/infrastructure/redis.rs
+++ b/crates/api/src/infrastructure/redis.rs
@@ -53,7 +53,11 @@ impl RedisClient {
             .collect()
     }
 
-    /// SCAN all keys matching a pattern, releasing the lock between iterations.
+    pub async fn health_check(&self) -> bool {
+        let mut conn = self.conn.lock().await;
+        redis::cmd("PING").query_async::<String>(&mut *conn).await.is_ok()
+    }
+
     async fn scan_keys(&self, pattern: &str) -> Vec<String> {
         let mut all_keys = Vec::new();
         let mut cursor: u64 = 0;

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -5,12 +5,16 @@ use tower_http::trace::TraceLayer;
 
 use crate::api::{
     cancel_run, create_run, delete_run, get_run_log, get_run_status, get_service_info, get_task,
-    list_log_lines, list_runs, list_tasks, stream_log_lines, stream_run_status,
+    healthz, list_log_lines, list_runs, list_tasks, readyz, startupz, stream_log_lines,
+    stream_run_status,
 };
 use crate::state::AppState;
 
 pub fn get_router(app_state: AppState) -> Router {
     Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .route("/startupz", get(startupz))
         .route("/service-info", get(get_service_info))
         .route("/runs", get(list_runs).post(create_run))
         .route("/runs/{run_id}", get(get_run_log).delete(delete_run))

--- a/crates/api/src/services/run.rs
+++ b/crates/api/src/services/run.rs
@@ -163,4 +163,8 @@ impl RunService {
     pub fn redis(&self) -> &Arc<RedisClient> {
         &self.redis
     }
+
+    pub fn nats(&self) -> &Arc<NatsPublisher> {
+        &self.nats
+    }
 }

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -54,11 +54,8 @@ impl AppState {
             service_info: service_info_service,
         };
 
-        Ok(Self {
-            db,
-            services,
-            config: config.clone(),
-            boot_time: Arc::new(RwLock::new(None)),
-        })
+        let boot_time = Arc::new(RwLock::new(Some(Utc::now())));
+
+        Ok(Self { db, services, config: config.clone(), boot_time })
     }
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -2,6 +2,7 @@
 anyhow = "1.0.102"
 async-nats = { workspace = true }
 async-trait = "0.1.89"
+axum = { version = "0.8.8" }
 chrono = { features = [ "serde" ], version = "0.4.44" }
 common = { path = "../common" }
 envy = "0.4"

--- a/crates/engine/src/clients/db.rs
+++ b/crates/engine/src/clients/db.rs
@@ -224,4 +224,8 @@ impl Db {
 
         Ok(())
     }
+
+    pub async fn health_check(&self) -> bool {
+        sqlx::query("SELECT 1").fetch_one(&self.pool).await.is_ok()
+    }
 }

--- a/crates/engine/src/clients/nats.rs
+++ b/crates/engine/src/clients/nats.rs
@@ -92,4 +92,8 @@ impl Nats {
             .map_err(|e| EngineError::Network(e.to_string()))?;
         Ok(())
     }
+
+    pub fn health_check(&self) -> bool {
+        matches!(self.client.connection_state(), async_nats::connection::State::Connected)
+    }
 }

--- a/crates/engine/src/clients/valkey.rs
+++ b/crates/engine/src/clients/valkey.rs
@@ -85,6 +85,11 @@ impl Valkey {
         let _: () = conn.del(key).await?;
         Ok(())
     }
+
+    pub async fn health_check(&self) -> bool {
+        let mut conn = self.conn.lock().await;
+        redis::cmd("PING").query_async::<String>(&mut *conn).await.is_ok()
+    }
 }
 
 #[tokio::test]

--- a/crates/engine/src/config.rs
+++ b/crates/engine/src/config.rs
@@ -3,6 +3,10 @@ use url::Url;
 
 use crate::error::{EngineError, EngineResult};
 
+fn default_health_port() -> u16 {
+    8080
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServerConfig {
     pub database_url: Url,
@@ -10,6 +14,8 @@ pub struct ServerConfig {
     #[serde(default = "default_notification_subject")]
     pub nats_notification_subject: String,
     pub redis_url: Url,
+    #[serde(default = "default_health_port")]
+    pub health_port: u16,
 }
 
 fn default_notification_subject() -> String {

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -1,0 +1,73 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use serde_json::json;
+use tokio::net::TcpListener;
+
+use crate::config::ServerConfig;
+use crate::error::EngineResult;
+use crate::runtime::EngineRuntime;
+
+#[derive(Clone)]
+struct HealthState {
+    runtime: Arc<EngineRuntime>,
+}
+
+pub async fn start_health_server(
+    config: Arc<ServerConfig>,
+    runtime: Arc<EngineRuntime>,
+) -> EngineResult<()> {
+    let state = HealthState { runtime };
+    let addr = SocketAddr::from(([0, 0, 0, 0], config.health_port));
+    tracing::info!("Health server listening on {}", addr);
+
+    let app = axum::Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .route("/startupz", get(startupz))
+        .with_state(state);
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    tracing::info!("Health server stopped");
+    Ok(())
+}
+
+async fn healthz() -> impl IntoResponse {
+    Json(json!({ "status": "ok" }))
+}
+
+async fn readyz(State(state): State<HealthState>) -> impl IntoResponse {
+    Json(json!({
+        "status": "ok",
+        "boot_time": state.runtime.boot_time().to_rfc3339()
+    }))
+}
+
+async fn startupz(State(state): State<HealthState>) -> impl IntoResponse {
+    let runtime = state.runtime.clone();
+    let redis_ok = runtime.health_check_redis().await;
+    let nats_ok = runtime.health_check_nats();
+    let db_ok = runtime.health_check_db().await;
+    let all_healthy = redis_ok && nats_ok && db_ok;
+    let status = if all_healthy {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        status,
+        Json(json!({
+            "status": if all_healthy { "ok" } else { "degraded" },
+            "checks": {
+                "redis": if redis_ok { "ok" } else { "error" },
+                "nats": if nats_ok { "ok" } else { "error" },
+                "db": if db_ok { "ok" } else { "error" }
+            }
+        })),
+    )
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -15,6 +15,7 @@ pub mod dry_run;
 pub mod engine;
 pub mod error;
 pub mod execution;
+pub mod health;
 pub mod models;
 pub mod pid_store;
 pub mod runtime;

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -44,6 +44,7 @@ pub struct EngineRuntime {
     pid_store: PidStore,
     cancelled_runs: Arc<RwLock<HashSet<Uuid>>>,
     dry_run: bool,
+    boot_time: DateTime<Utc>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,11 +74,34 @@ impl EngineRuntime {
             pid_store,
             cancelled_runs: Arc::new(RwLock::new(HashSet::new())),
             dry_run,
+            boot_time: Utc::now(),
         }
     }
 
     pub fn db(&self) -> Option<&Arc<Db>> {
         self.db.as_ref()
+    }
+
+    pub fn boot_time(&self) -> DateTime<Utc> {
+        self.boot_time
+    }
+
+    pub fn health_check_nats(&self) -> bool {
+        self.nats.as_ref().map(|n| n.health_check()).unwrap_or(false)
+    }
+
+    pub async fn health_check_redis(&self) -> bool {
+        match &self.valkey {
+            Some(v) => v.health_check().await,
+            None => false,
+        }
+    }
+
+    pub async fn health_check_db(&self) -> bool {
+        match &self.db {
+            Some(db) => db.health_check().await,
+            None => false,
+        }
     }
 
     pub async fn start(self: Arc<Self>) -> EngineResult<()> {

--- a/crates/engine/src/server.rs
+++ b/crates/engine/src/server.rs
@@ -3,16 +3,17 @@ use std::sync::Arc;
 use tokio::try_join;
 
 use crate::clients::{Db, Nats, Valkey};
-use crate::config::ServerConfig;
+use crate::config::{ServerConfig, load_engine_config};
 use crate::engine::Engine;
 use crate::error::EngineResult;
+use crate::health::start_health_server;
 use crate::runtime::EngineRuntime;
 
 pub async fn bootstrap<E>(engine: E) -> EngineResult<()>
 where
     E: Engine + 'static,
 {
-    let config = crate::config::load_engine_config().await?;
+    let config = load_engine_config().await?;
     let server_config = ServerConfig::from_env().map_err(|e| {
         crate::error::EngineError::Config(format!("Failed to load server config: {}", e))
     })?;
@@ -48,5 +49,13 @@ where
         Some(db),
         false,
     ));
+
+    let health_runtime = Arc::clone(&runtime);
+    tokio::spawn(async move {
+        if let Err(e) = start_health_server(Arc::new(server_config), health_runtime).await {
+            tracing::error!(error = %e, "Health server failed");
+        }
+    });
+
     runtime.start().await
 }


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Add dedicated health, readiness, and startup probe endpoints to both the engine and API services and wire them into a separate engine health server.

New Features:
- Expose /healthz, /readyz, and /startupz HTTP endpoints in the API service for basic status, readiness, and dependency health checks.
- Expose /healthz, /readyz, and /startupz HTTP endpoints in the engine via a dedicated Axum-based health server listening on a configurable port.
- Add lightweight health-check routines for database, Redis/Valkey, and NATS clients used by the engine and API.

Enhancements:
- Track and expose service boot time in the engine and API state for use in readiness responses.
- Extend engine configuration to support a configurable health server port.