### PR TITLE
feat: centralize logging and otel export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,19 @@
 [workspace]
-members = [ "crates/api", "crates/common", "crates/engine", "crates/engines/generic" ]
+members = [
+  "crates/api",
+  "crates/common",
+  "crates/engine",
+  "crates/engines/generic",
+  "crates/telemetry",
+]
 resolver = "3"
 
 [workspace.dependencies]
 async-nats = "0.44.2"
 envy = "0.4.2"
+opentelemetry = { version = "0.27" }
+opentelemetry-otlp = { features = [ "grpc-tonic", "tonic" ], version = "0.27" }
+opentelemetry_sdk = { features = [ "rt-tokio" ], version = "0.27" }
 redis = { features = [ "aio", "tokio-comp" ], version = "0.32.7" }
 serde = { features = [ "derive" ], version = "1.0.228" }
 serde_json = "1.0"
@@ -17,8 +26,10 @@ sqlx = { default-features = false, features = [
   "runtime-tokio-rustls",
   "uuid",
 ], version = "0.8.6" }
+telemetry = { path = "crates/telemetry" }
 tokio = { features = [ "full" ], version = "1.50.0" }
 tracing = "0.1.44"
+tracing-opentelemetry = { version = "0.28" }
 tracing-subscriber = { features = [ "env-filter", "json" ], version = "0.3.22" }
 utoipa = { features = [ "axum_extras", "chrono", "uuid" ], version = "5.4.0" }
-uuid = { features = [ "serde", "v7" ], version = "1.21.0" }
+uuid = { features = [ "serde", "v7" ], version = "1.22.0" }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -24,11 +24,11 @@ sqlx = { features = [
   "runtime-tokio-rustls",
   "uuid",
 ], workspace = true }
+telemetry = { workspace = true }
 thiserror = "2.0.18"
 tokio = { features = [ "full" ], workspace = true }
 tokio-stream = "0.1.18"
 tower-http = { features = [ "cors", "trace" ], version = "0.6.8" }
-tracing-subscriber = { features = [ "env-filter", "json" ], workspace = true }
 url = "2.5.8"
 utoipa = { features = [ "axum_extras", "chrono", "uuid" ], workspace = true }
 utoipa-swagger-ui = { features = [ "axum" ], version = "9" }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -7,6 +7,7 @@ pub mod repositories;
 pub mod routes;
 pub mod services;
 pub mod state;
+pub mod tracing;
 
 pub use api::{ApiError, ApiResult};
 pub use config::Config;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -5,19 +5,12 @@ use chrono::Utc;
 use common::models::State;
 use metis_api::docs::docs;
 use metis_api::routes::get_router;
+use metis_api::tracing::init_tracing;
 use metis_api::{AppState, Config};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    init_tracing();
 
     let config = Config::from_env()?;
     let state = AppState::new(&config).await?;

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -2,6 +2,7 @@ use axum::Router;
 use axum::routing::{get, post};
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
+use tracing::Level;
 
 use crate::api::{
     cancel_run, create_run, delete_run, get_run_log, get_run_status, get_service_info, get_task,
@@ -25,7 +26,12 @@ pub fn get_router(app_state: AppState) -> Router {
         .route("/runs/{run_id}/tasks/{task_id}", get(get_task))
         .route("/runs/{run_id}/logs", get(list_log_lines))
         .route("/runs/{run_id}/logs/stream", get(stream_log_lines))
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(tower_http::trace::DefaultMakeSpan::new().level(Level::INFO))
+                .on_response(tower_http::trace::DefaultOnResponse::new().level(Level::INFO))
+                .on_failure(tower_http::trace::DefaultOnFailure::new().level(Level::ERROR)),
+        )
         .layer(CorsLayer::permissive())
         .with_state(app_state)
 }

--- a/crates/api/src/routes.rs
+++ b/crates/api/src/routes.rs
@@ -12,10 +12,7 @@ use crate::api::{
 use crate::state::AppState;
 
 pub fn get_router(app_state: AppState) -> Router {
-    Router::new()
-        .route("/healthz", get(healthz))
-        .route("/readyz", get(readyz))
-        .route("/startupz", get(startupz))
+    let api_routes = Router::new()
         .route("/service-info", get(get_service_info))
         .route("/runs", get(list_runs).post(create_run))
         .route("/runs/{run_id}", get(get_run_log).delete(delete_run))
@@ -31,7 +28,13 @@ pub fn get_router(app_state: AppState) -> Router {
                 .make_span_with(tower_http::trace::DefaultMakeSpan::new().level(Level::INFO))
                 .on_response(tower_http::trace::DefaultOnResponse::new().level(Level::INFO))
                 .on_failure(tower_http::trace::DefaultOnFailure::new().level(Level::ERROR)),
-        )
+        );
+
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .route("/startupz", get(startupz))
+        .merge(api_routes)
         .layer(CorsLayer::permissive())
         .with_state(app_state)
 }

--- a/crates/api/src/services/run.rs
+++ b/crates/api/src/services/run.rs
@@ -40,6 +40,10 @@ impl RunService {
         self.repo.find_all(filter, pagination).await.map_err(Into::into)
     }
 
+    #[tracing::instrument(
+        skip(self, req),
+        fields(run_id = %run_id, user_id = %user_id, workflow_type = %req.workflow_type, workflow_engine = %req.workflow_engine)
+    )]
     pub async fn create_run(
         &self,
         run_id: &str,
@@ -62,10 +66,12 @@ impl RunService {
         let validator = EngineRequestValidator::new(engine_config);
         let validated = validator.validate(req).map_err(ServiceError::Validation)?;
 
+        let trace_id = tracing::Span::current().id().map(|id| format!("{:x}", id.into_u64()));
         let message = RunRequestMessage {
             run_id: run_id.to_string(),
             request: validated,
             user_id: user_id.to_string(),
+            trace_id,
         };
 
         let topic = common::keys::nats_run_subject(
@@ -77,9 +83,19 @@ impl RunService {
 
         self.nats.publish_run(&topic, &message).await.map_err(ServiceError::Messaging)?;
 
+        tracing::info!(
+            run_id = %run_id,
+            user_id = %user_id,
+            workflow_type = %req.workflow_type,
+            workflow_engine = %req.workflow_engine,
+            nats_topic = %topic,
+            "Run created and dispatched"
+        );
+
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(run_id = %id))]
     pub async fn request_cancel(&self, id: &RunId) -> ServiceResult<Option<String>> {
         loop {
             let run = self
@@ -93,6 +109,7 @@ impl RunService {
                     let updated =
                         self.repo.update_state_if(id, State::Queued, State::Canceled).await?;
                     if updated {
+                        tracing::info!(run_id = %id, "Queued run canceled immediately");
                         return Ok(None);
                     }
                 },
@@ -108,6 +125,12 @@ impl RunService {
                         .publish_cancel(&engine_id, id.as_str())
                         .await
                         .map_err(ServiceError::Messaging)?;
+
+                    tracing::info!(
+                        run_id = %id,
+                        engine_id = %engine_id,
+                        "Cancel signal dispatched to engine"
+                    );
 
                     return Ok(Some(engine_id));
                 },

--- a/crates/api/src/tracing.rs
+++ b/crates/api/src/tracing.rs
@@ -1,0 +1,3 @@
+pub fn init_tracing() {
+    telemetry::init_tracing("metis-api");
+}

--- a/crates/common/src/models.rs
+++ b/crates/common/src/models.rs
@@ -965,4 +965,5 @@ pub struct RunRequestMessage {
     pub run_id: String,
     pub request: ValidatedRunRequest,
     pub user_id: String,
+    pub trace_id: Option<String>,
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,6 +15,7 @@ serde_yaml = "0.9.34"
 sqlx = { workspace = true }
 telemetry = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 url = { features = [ "serde" ], version = "2.5.8" }
 uuid = { workspace = true }
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -13,8 +13,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9.34"
 sqlx = { workspace = true }
+telemetry = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
 url = { features = [ "serde" ], version = "2.5.8" }
 uuid = { workspace = true }
 

--- a/crates/engine/src/clients/db.rs
+++ b/crates/engine/src/clients/db.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use common::models::{Log, State, TaskLog, ValidatedRunRequest};
 use sqlx::PgPool;
-use tracing::debug;
+use telemetry::tracing::debug;
 
 use crate::error::{EngineError, EngineResult};
 

--- a/crates/engine/src/config.rs
+++ b/crates/engine/src/config.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use telemetry::tracing;
 use url::Url;
 
 use crate::error::{EngineError, EngineResult};

--- a/crates/engine/src/execution.rs
+++ b/crates/engine/src/execution.rs
@@ -1,9 +1,9 @@
 use std::process::ExitStatus;
 use std::sync::Arc;
 
+use telemetry::tracing::{debug, info, warn};
 use tokio::io::AsyncBufReadExt;
 use tokio::process::{Child, Command};
-use tracing::{debug, info, warn};
 
 use crate::clients::db::Stream;
 use crate::error::{EngineError, EngineResult};

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -6,6 +6,7 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use axum::routing::get;
 use serde_json::json;
+use telemetry::tracing;
 use tokio::net::TcpListener;
 
 use crate::config::ServerConfig;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -28,4 +28,5 @@ pub use error::{EngineError, EngineResult};
 pub use execution::{ExecutionOutput, ProcessExecutor};
 pub use pid_store::PidStore;
 pub use runtime::EngineRuntime;
+pub use telemetry::init_tracing;
 pub use workdir::{WorkdirManager, WorkdirPaths};

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -8,8 +8,8 @@ use common::configs::FullEngineConfig;
 use common::models::{RunRequestMessage, RunSummary, State, TaskListResponse, ValidatedRunRequest};
 use futures::StreamExt;
 use serde::Deserialize;
+use telemetry::tracing::{self, Instrument, error, info, warn};
 use tokio::sync::RwLock;
-use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::clients::db::Stream;
@@ -76,6 +76,10 @@ impl EngineRuntime {
             dry_run,
             boot_time: Utc::now(),
         }
+    }
+
+    pub fn config(&self) -> &Arc<FullEngineConfig> {
+        &self.config
     }
 
     pub fn db(&self) -> Option<&Arc<Db>> {
@@ -198,7 +202,9 @@ impl EngineRuntime {
             valkey.add_run(&run_id.to_string()).await?;
         }
 
-        let run_result = self.run(run_id, run_message.user_id.clone(), run_message.request).await;
+        let run_result = self
+            .run(run_id, run_message.user_id.clone(), run_message.request, run_message.trace_id)
+            .await;
 
         if let Some(valkey) = &self.valkey {
             valkey.remove_run(&run_id.to_string()).await?;
@@ -221,7 +227,7 @@ impl EngineRuntime {
                     && let Err(db_err) =
                         db.finalize_run(&run_id.to_string(), State::SystemError, Utc::now()).await
                 {
-                    warn!(run_id = %run_id, error = %db_err, "Failed to record failed run in database");
+                    error!(run_id = %run_id, error = %db_err, "Failed to record failed run in database");
                 }
                 if let Some(nats) = &self.nats {
                     let event = serde_json::json!({
@@ -290,6 +296,38 @@ impl EngineRuntime {
         run_id: Uuid,
         user_id: String,
         req: ValidatedRunRequest,
+        trace_id: Option<String>,
+    ) -> Result<RunSummary, EngineError> {
+        let span = tracing::info_span!(
+            "workflow_run",
+            run_id = %run_id,
+            user_id = %user_id,
+            workflow_type = %req.workflow_type,
+            state = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+            api_trace_id = tracing::field::Empty,
+            error = tracing::field::Empty,
+        );
+        if let Some(ref tid) = trace_id {
+            span.record("api_trace_id", tid.as_str());
+        }
+        async move {
+            let result = self.run_inner(run_id, user_id, req).await;
+            if let Err(ref e) = result {
+                tracing::Span::current().record("error", e.to_string().as_str());
+                error!(error = %e, "Workflow execution failed");
+            }
+            result
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn run_inner(
+        &self,
+        run_id: Uuid,
+        user_id: String,
+        req: ValidatedRunRequest,
     ) -> Result<RunSummary, EngineError> {
         let start_time = Instant::now();
         let started_at = Utc::now();
@@ -306,14 +344,6 @@ impl EngineRuntime {
             command: None,
         };
 
-        let span = tracing::info_span!(
-            "workflow_run",
-            run_id = %ctx.run_id,
-            workflow_type = %req.workflow_type,
-            state = tracing::field::Empty,
-            duration_ms = tracing::field::Empty,
-        );
-
         info!(
             run_id = %ctx.run_id,
             workflow_type = %req.workflow_type,
@@ -323,7 +353,7 @@ impl EngineRuntime {
         );
 
         // Step 1: Setup execution environment
-        span.record("state", "initializing");
+        tracing::Span::current().record("state", "initializing");
         WorkdirManager::setup(&ctx.workdir).await?;
 
         if let Some(db) = &self.db
@@ -334,7 +364,7 @@ impl EngineRuntime {
         }
 
         // Step 2: Build execution command
-        span.record("state", "building");
+        tracing::Span::current().record("state", "building");
         let build_context = self.create_build_context(&ctx).await?;
 
         let engine_params = self
@@ -389,7 +419,7 @@ impl EngineRuntime {
         }
 
         // Step 3: Execute workflow process
-        span.record("state", "executing");
+        tracing::Span::current().record("state", "executing");
         let child_process = ProcessExecutor::execute(&command_info).await?;
         let pid = child_process
             .id()
@@ -406,7 +436,7 @@ impl EngineRuntime {
         }
 
         // Step 4: Monitor execution (this blocks until completion or cancellation)
-        span.record("state", "running");
+        tracing::Span::current().record("state", "running");
         let line_callback: Arc<dyn Fn(Stream, u64, String) + Send + Sync + 'static> = {
             let db = self.db.clone();
             let run_id = ctx.run_id.to_string();
@@ -427,21 +457,21 @@ impl EngineRuntime {
         let is_cancelled = self.is_run_cancelled(&ctx.run_id).await;
 
         // Step 5: Parse results regardless of success/failure/cancellation
-        span.record("state", "parsing");
+        tracing::Span::current().record("state", "parsing");
         let (run_summary, run_log, task_logs) =
             self.parse_execution_results(&ctx, &exit_status, is_cancelled).await?;
 
         // Step 6: Update database with results
-        span.record("state", "updating_db");
+        tracing::Span::current().record("state", "updating_db");
         self.update_database(&ctx, &run_summary, &run_log, &task_logs).await?;
 
         // Step 7: Cleanup
-        span.record("state", "cleanup");
+        tracing::Span::current().record("state", "cleanup");
         self.cleanup_execution(&ctx).await?;
 
         let duration_ms = start_time.elapsed().as_millis() as u64;
-        span.record("duration_ms", duration_ms);
-        span.record("state", format!("{:?}", run_summary.state).as_str());
+        tracing::Span::current().record("duration_ms", duration_ms);
+        tracing::Span::current().record("state", format!("{:?}", run_summary.state).as_str());
 
         info!(
             duration_ms = duration_ms,
@@ -454,29 +484,33 @@ impl EngineRuntime {
 
     /// Cancel a running workflow - FINAL, cannot be overridden
     pub async fn cancel(&self, run_id: &str) -> Result<(), EngineError> {
-        let _span = tracing::info_span!("workflow_cancel", run_id = %run_id);
-        info!(run_id = %run_id, "Cancelling workflow");
+        let span = tracing::info_span!("workflow_cancel", run_id = %run_id);
+        async move {
+            info!(run_id = %run_id, "Cancelling workflow");
 
-        if let Ok(parsed) = Uuid::parse_str(run_id) {
-            self.cancelled_runs.write().await.insert(parsed);
+            if let Ok(parsed) = Uuid::parse_str(run_id) {
+                self.cancelled_runs.write().await.insert(parsed);
+            }
+
+            let pid = match self.pid_store.get(run_id).await? {
+                Some(pid) => pid,
+                None => {
+                    warn!("No PID found for run_id, workflow may have already completed");
+                    return Ok(());
+                },
+            };
+
+            info!(pid = pid, "Found process to cancel");
+
+            // Send cancellation signal
+            ProcessExecutor::cancel(pid).await?;
+            self.pid_store.remove(run_id).await?;
+
+            info!("Workflow cancellation completed");
+            Ok(())
         }
-
-        let pid = match self.pid_store.get(run_id).await? {
-            Some(pid) => pid,
-            None => {
-                warn!("No PID found for run_id, workflow may have already completed");
-                return Ok(());
-            },
-        };
-
-        info!(pid = pid, "Found process to cancel");
-
-        // Send cancellation signal
-        ProcessExecutor::cancel(pid).await?;
-        self.pid_store.remove(run_id).await?;
-
-        info!("Workflow cancellation completed");
-        Ok(())
+        .instrument(span)
+        .await
     }
 
     async fn is_run_cancelled(&self, run_id: &Uuid) -> bool {
@@ -559,17 +593,17 @@ impl EngineRuntime {
         let end_time = Utc::now();
 
         if let Err(e) = db.finalize_run(&ctx.run_id.to_string(), state, end_time).await {
-            warn!(run_id = %ctx.run_id, error = %e, "Failed to finalize run in database");
+            error!(run_id = %ctx.run_id, error = %e, "Failed to finalize run in database");
         }
 
         if let Err(e) = db.insert_run_log(&ctx.run_id.to_string(), run_log).await {
-            warn!(run_id = %ctx.run_id, error = %e, "Failed to insert run log");
+            error!(run_id = %ctx.run_id, error = %e, "Failed to insert run log");
         }
 
         if let Some(tasks) = &task_logs.task_logs
             && let Err(e) = db.insert_task_logs(&ctx.run_id.to_string(), tasks).await
         {
-            warn!(run_id = %ctx.run_id, error = %e, "Failed to insert task logs");
+            error!(run_id = %ctx.run_id, error = %e, "Failed to insert task logs");
         }
 
         Ok(())

--- a/crates/engine/src/server.rs
+++ b/crates/engine/src/server.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use telemetry::init_tracing;
+use telemetry::tracing::{self, info};
 use tokio::try_join;
 
 use crate::clients::{Db, Nats, Valkey};
@@ -9,10 +11,11 @@ use crate::error::EngineResult;
 use crate::health::start_health_server;
 use crate::runtime::EngineRuntime;
 
-pub async fn bootstrap<E>(engine: E) -> EngineResult<()>
+pub async fn bootstrap<E>(engine: E, name: &'static str) -> EngineResult<()>
 where
     E: Engine + 'static,
 {
+    init_tracing(name);
     let config = load_engine_config().await?;
     let server_config = ServerConfig::from_env().map_err(|e| {
         crate::error::EngineError::Config(format!("Failed to load server config: {}", e))
@@ -49,6 +52,14 @@ where
         Some(db),
         false,
     ));
+
+    info!(
+        engine_id = %runtime.config().engine.id,
+        engine_name = %runtime.config().engine.name,
+        engine_version = %runtime.config().engine.version,
+        health_port = server_config.health_port,
+        "Engine starting up"
+    );
 
     let health_runtime = Arc::clone(&runtime);
     tokio::spawn(async move {

--- a/crates/engine/src/workdir.rs
+++ b/crates/engine/src/workdir.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use chrono::Utc;
 use common::configs::FullEngineConfig;
-use tracing::error;
+use telemetry::tracing::error;
 
 use crate::error::{EngineError, EngineResult};
 use crate::models::BuildContext;

--- a/crates/engines/generic/src/main.rs
+++ b/crates/engines/generic/src/main.rs
@@ -26,5 +26,5 @@ impl Engine for GenericEngine {
 #[tokio::main]
 async fn main() -> EngineResult<()> {
     let engine = GenericEngine;
-    server::bootstrap(engine).await
+    server::bootstrap(engine, "metis-engine-generic").await
 }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,0 +1,12 @@
+[dependencies]
+opentelemetry = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-subscriber = { features = [ "env-filter", "json" ], workspace = true }
+
+[package]
+edition = "2024"
+name = "telemetry"
+version = "0.1.0"

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -1,0 +1,38 @@
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig;
+pub use tracing;
+pub use tracing_subscriber;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+pub fn init_tracing(service_name: &'static str) {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let use_json = std::env::var("LOG_FORMAT")
+        .map(|v| v.eq_ignore_ascii_case("json"))
+        .unwrap_or(false);
+
+    let registry = tracing_subscriber::registry().with(filter);
+
+    if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+        let exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint)
+            .build()
+            .expect("Failed to build OTEL exporter");
+        let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+            .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+            .build();
+        let tracer = tracer_provider.tracer(service_name);
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        if use_json {
+            registry.with(otel_layer).with(tracing_subscriber::fmt::layer().json()).init();
+        } else {
+            registry.with(otel_layer).with(tracing_subscriber::fmt::layer()).init();
+        }
+    } else if use_json {
+        registry.with(tracing_subscriber::fmt::layer().json()).init();
+    } else {
+        registry.with(tracing_subscriber::fmt::layer()).init();
+    }
+}

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -15,22 +15,38 @@ pub fn init_tracing(service_name: &'static str) {
     let registry = tracing_subscriber::registry().with(filter);
 
     if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
-        let exporter = opentelemetry_otlp::SpanExporter::builder()
+        match opentelemetry_otlp::SpanExporter::builder()
             .with_tonic()
             .with_endpoint(endpoint)
             .build()
-            .expect("Failed to build OTEL exporter");
-        let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
-            .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
-            .build();
-        let tracer = tracer_provider.tracer(service_name);
-        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
-        if use_json {
-            registry.with(otel_layer).with(tracing_subscriber::fmt::layer().json()).init();
-        } else {
-            registry.with(otel_layer).with(tracing_subscriber::fmt::layer()).init();
+        {
+            Ok(exporter) => {
+                let resource =
+                    opentelemetry_sdk::Resource::new(vec![opentelemetry::KeyValue::new(
+                        "service.name",
+                        service_name,
+                    )]);
+                let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+                    .with_resource(resource)
+                    .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+                    .build();
+                let tracer = tracer_provider.tracer(service_name);
+                let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+                if use_json {
+                    registry.with(otel_layer).with(tracing_subscriber::fmt::layer().json()).init();
+                } else {
+                    registry.with(otel_layer).with(tracing_subscriber::fmt::layer()).init();
+                }
+                return;
+            },
+            Err(e) => {
+                eprintln!(
+                    "warn: failed to build OTEL exporter, falling back to local logging: {e}"
+                );
+            },
         }
-    } else if use_json {
+    }
+    if use_json {
         registry.with(tracing_subscriber::fmt::layer().json()).init();
     } else {
         registry.with(tracing_subscriber::fmt::layer()).init();

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -39,6 +39,13 @@ export default withMermaid(
                         { text: "Architecture", link: "/architecture" },
                     ],
                 },
+                {
+                    text: "Dev",
+                    items: [
+                        { text: "Engine Internals", link: "/dev/engine" },
+                        { text: "Tracing", link: "/dev/tracing" },
+                    ],
+                },
             ],
             search: {
                 provider: "local",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3,8 +3,12 @@
 Metis closely follows the [GA4GH WES 1.1.0](https://ga4gh.github.io/workflow-execution-service-schemas/) standard,
 extending it with SSE streaming, log pagination, and soft-delete.
 
-The interactive API docs are available at `http://<host>:<port>/docs` when the API is running.
-All request and response schemas are documented there.
+::: note live documentation
+Interactive API documentation is available at `http://<host>:<port>/docs`
+when the API is running. It contains the complete and most up-to-date
+request and response schemas. This page is provided for reference only
+and may lag behind the live documentation.
+:::
 
 ## Base URL
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,13 +170,4 @@ Terminal states: `COMPLETE`, `EXECUTOR_ERROR`, `CANCELED`, `SYSTEM_ERROR`
 
 ## Crate Structure
 
-| Crate | Purpose |
-| ----- | ------- |
-| `api` | Axum HTTP server, route handlers, request validation |
-| `engine` | `Engine` trait definition, shared runtime (NATS subscription, process execution, log capture) |
-| `engine-nextflow` | Nextflow-specific `Engine` impl — result parsing, task log extraction |
-| `db` | SQLx models and query functions for PostgreSQL |
-| `config` | `engine.yaml` deserialization and validation logic |
-| `types` | Shared domain types (RunState, RunId, etc.) |
-
-The `engine` crate contains all execution plumbing. New engine implementations live in their own crate and only need to provide the trait methods.
+See [Engine Internals](/dev/engine) for the crate breakdown and how to add a custom engine.

--- a/docs/dev/engine.md
+++ b/docs/dev/engine.md
@@ -1,0 +1,35 @@
+# Engine Internals
+
+## Crate Structure
+
+| Crate | Purpose |
+| ----- | ------- |
+| `api` | Axum HTTP server, route handlers, request validation |
+| `engine` | `Engine` trait, shared runtime (NATS subscription, process execution, log capture) |
+| `engines/generic` | Generic binary — reads `engine.yaml`, delegates trait methods |
+| `common` | Shared domain types (`RunState`, `RunId`, etc.) |
+| `telemetry` | Tracing/subscriber init, re-exports `tracing` and `tracing_subscriber` |
+
+## Engine Trait
+
+New engines implement two methods:
+
+```rust
+pub trait Engine: Send + Sync {
+    fn new() -> Self;
+    async fn get_workflow_results() -> Result<HashMap<Category, Files>>;
+    async fn get_task_logs() -> Result<Vec<TaskLog>>;
+}
+```
+
+Everything else — NATS subscription, process execution, log capture, state transitions — is handled by the shared `engine` crate runtime.
+
+## Adding a Custom Engine
+
+1. Create a new crate that depends on `engine`.
+2. Implement the `Engine` trait for result parsing and task log extraction.
+3. Call `engine::server::bootstrap(MyEngine::new(), "my-engine-name").await` from `main`.
+4. Write an `engine.yaml` — see [Engine Configuration](/engine-configuration) for the full reference.
+5. Start the binary with `ENGINE_CONFIG_PATH` pointing at the config file.
+
+For engines that don't need custom parsing, `metis-engine-generic` with an `engine.yaml` is sufficient — no custom binary required.

--- a/docs/dev/engine.md
+++ b/docs/dev/engine.md
@@ -12,7 +12,7 @@
 
 ## Engine Trait
 
-New engines implement two methods:
+New engines implement the following methods:
 
 ```rust
 pub trait Engine: Send + Sync {

--- a/docs/dev/tracing.md
+++ b/docs/dev/tracing.md
@@ -1,0 +1,56 @@
+# Tracing
+
+Metis uses [`tracing`](https://docs.rs/tracing) for structured logs and spans. Both `metis-api` and engine binaries share the same setup via `telemetry::init_tracing(service_name)`.
+
+## Log Format
+
+Default output is human-readable text. Set `LOG_FORMAT=json` for newline-delimited JSON — one object per line with `timestamp`, `level`, `span`, and `fields`.
+
+```bash
+LOG_FORMAT=json ./metis-api
+```
+
+## Log Level
+
+Controlled via `RUST_LOG`:
+
+```bash
+RUST_LOG=info              # default
+RUST_LOG=debug             # verbose
+RUST_LOG=metis_api=debug   # per-crate
+```
+
+## Key Spans
+
+| Span              | Crate  | Notable fields                                                                        |
+| ----------------- | ------ | ------------------------------------------------------------------------------------- |
+| `create_run`      | API    | `run_id`, `user_id`, `workflow_type`, `workflow_engine`                               |
+| `request_cancel`  | API    | `run_id`                                                                              |
+| `workflow_run`    | Engine | `run_id`, `user_id`, `workflow_type`, `state`, `duration_ms`, `api_trace_id`, `error` |
+| `workflow_cancel` | Engine | `run_id`                                                                              |
+
+`state` on `workflow_run` is recorded at each phase: `initializing → building → executing → running → parsing → updating_db → cleanup`. `api_trace_id` links the engine span back to the originating API span.
+
+## NATS Trace Correlation
+
+When the API dispatches a run it embeds the current span ID as `trace_id` in the NATS message. The engine records it as `api_trace_id` on the `workflow_run` span, enabling cross-service correlation in any log aggregator without full distributed tracing.
+
+## OTEL Export
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to export spans to any OTLP-compatible collector (SigNoz, Jaeger, Tempo, Datadog, etc.). The layer activates automatically; no other config is needed.
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://signoz-collector:4317 ./metis-api
+```
+
+## Dependency
+
+`tracing` and `tracing_subscriber` are not direct deps of `api` or `engine` — they are re-exported from `telemetry`:
+
+```rust
+// crates/telemetry/src/lib.rs
+pub use tracing;
+pub use tracing_subscriber;
+```
+
+Import via `telemetry::tracing` rather than adding a direct dep. The exception is `api`, which keeps a direct `tracing` dep because the `#[tracing::instrument]` proc-macro resolves the crate by name at expansion time.

--- a/docs/engine-configuration.md
+++ b/docs/engine-configuration.md
@@ -1,16 +1,9 @@
 # Engine Configuration
 
-Engine behaviour in Metis is entirely defined by `engine.yaml`. No code changes are required to add a new engine variant or adjust how parameters are handled.
-
-## What is an Engine?
-
-An engine is a combination of:
-
-1. A **binary** (`metis-engine-generic`) that handles NATS subscription, process execution, log capture, and state transitions
-2. A **config file** (`engine.yaml`) that defines how to build CLI commands, validate parameters, and lay out the working directory
-3. An optional **trait implementation** for engine-specific result parsing and task log extraction
-
-The generic binary reads `engine.yaml` at startup and handles the rest automatically.
+`engine.yaml` is the sole configuration surface for an engine — no code
+changes needed to add a new variant or adjust parameter handling.
+For the crate structure and how to build a custom engine binary,
+see [Engine Internals](/dev/engine).
 
 ## Starting an Engine
 
@@ -71,14 +64,7 @@ Denied params are evaluated against the raw keys sent by the client before alias
 
 ## Registering a New Engine
 
-1. Write an `engine.yaml` for the new engine.
-2. Start `metis-engine-generic`:
-
-  ```bash
-  metis-engine-generic server --engine-config /path/to/engine.yaml
-  ```
-
-1. The engine registers its heartbeat in Valkey — it will appear in `GET /service-info`.
-2. Submit runs with `workflow_engine` matching `engine.name` in the config.
-
-For engines requiring custom result parsing or task log extraction, implement the `Engine` trait in a new crate and compile a custom binary.
+The engine registers its heartbeat in Valkey and appears in GET /service-info.
+Submit runs using a `workflow_engine` that matches `engine.name`. For custom
+parsing or log handling, implement the Engine trait and build a custom binary.
+See [Engine Internals → Adding a Custom Engine](/dev/engine#adding-a-custom-engine).


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Centralize tracing and logging setup across API and engine services, enabling optional OpenTelemetry export and improved workflow run observability.

New Features:
- Introduce a shared telemetry crate that configures tracing, supports JSON log output, and optionally exports spans to an OTLP endpoint.
- Propagate an API span identifier through NATS run requests so engine workflow spans can be correlated back to the originating API call.

Enhancements:
- Refine workflow and cancellation logging in the engine and API with structured spans, additional context fields, and clearer log levels.
- Initialize tracing in the engine bootstrap and API startup using the shared telemetry initialization function.
- Adjust HTTP tracing on API routes to log responses at info level and failures at error level, and treat certain database write failures as errors instead of warnings.

Build:
- Add a new telemetry crate to the workspace and wire shared OpenTelemetry and tracing dependencies through workspace configuration.

Documentation:
- Document engine internals and crate structure for developers, including how to add custom engines.
- Add tracing documentation covering span structure, configuration via environment variables, NATS trace correlation, and OTEL export setup.
- Simplify and cross-link engine configuration and architecture docs to point to the new engine internals documentation.