### PR TITLE
refactor: cleanup api contract

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -5,7 +5,6 @@ path = "src/main.rs"
 [dependencies]
 async-nats = { workspace = true }
 async-stream = "0.3.6"
-async-trait = "0.1.89"
 axum = { features = [ "macros" ], version = "0.8.8" }
 axum-extra = { features = [ "query", "typed-header" ], version = "0.12.5" }
 base64 = "0.22.1"

--- a/crates/api/src/repositories/log.rs
+++ b/crates/api/src/repositories/log.rs
@@ -1,18 +1,6 @@
-use async_trait::async_trait;
 use sqlx::{PgPool, Row};
 
 use super::{LogLine, LogStream, PaginatedResult, RepositoryResult, RunId};
-
-#[async_trait]
-pub trait LogRepository: Send + Sync {
-    async fn find_lines(
-        &self,
-        run_id: &RunId,
-        stream: Option<LogStream>,
-        after_seq: Option<i64>,
-        page_size: u32,
-    ) -> RepositoryResult<PaginatedResult<LogLine>>;
-}
 
 pub struct SqlxLogRepository {
     pool: PgPool,
@@ -24,9 +12,8 @@ impl SqlxLogRepository {
     }
 }
 
-#[async_trait]
-impl LogRepository for SqlxLogRepository {
-    async fn find_lines(
+impl SqlxLogRepository {
+    pub async fn find_lines(
         &self,
         run_id: &RunId,
         stream: Option<LogStream>,

--- a/crates/api/src/repositories/mod.rs
+++ b/crates/api/src/repositories/mod.rs
@@ -6,8 +6,8 @@ mod schema;
 mod task;
 
 pub use error::{RepositoryError, RepositoryResult};
-pub use log::{LogRepository, SqlxLogRepository};
+pub use log::SqlxLogRepository;
 pub use pagination::{calculate_next_token, decode_offset, encode_offset, pagination_offset};
-pub use run::{PaginatedResult, Pagination, RunFilter, RunRepository, SqlxRunRepository};
+pub use run::{PaginatedResult, Pagination, RunFilter, SqlxRunRepository};
 pub use schema::{LogLine, LogStream, Run, RunId, State, Task, TaskId};
-pub use task::{SqlxTaskRepository, TaskRepository};
+pub use task::SqlxTaskRepository;

--- a/crates/api/src/repositories/run.rs
+++ b/crates/api/src/repositories/run.rs
@@ -1,39 +1,10 @@
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use common::models::RunRequest;
 use sqlx::{PgPool, Row};
 
 use super::{RepositoryResult, Run, RunId, State, calculate_next_token, pagination_offset};
-
-#[async_trait]
-pub trait RunRepository: Send + Sync {
-    async fn find_by_id(&self, id: &RunId) -> RepositoryResult<Option<Run>>;
-    async fn find_all(
-        &self,
-        filter: RunFilter,
-        pagination: Pagination,
-    ) -> RepositoryResult<PaginatedResult<Run>>;
-    async fn count_by_state(&self) -> RepositoryResult<HashMap<String, i64>>;
-    async fn insert_run(
-        &self,
-        run_id: &str,
-        user_id: &str,
-        req: &RunRequest,
-    ) -> RepositoryResult<()>;
-    async fn update_state(&self, id: &RunId, state: State) -> RepositoryResult<()>;
-    async fn update_state_if(
-        &self,
-        id: &RunId,
-        expected: State,
-        new: State,
-    ) -> RepositoryResult<bool>;
-    async fn find_active_runs(&self) -> RepositoryResult<Vec<Run>>;
-    async fn finalize_orphaned_run(&self, id: &RunId, state: State) -> RepositoryResult<()>;
-    async fn soft_delete(&self, id: &RunId) -> RepositoryResult<bool>;
-    async fn find_run_log(&self, run_id: &RunId) -> RepositoryResult<Option<common::models::Log>>;
-}
 
 pub struct SqlxRunRepository {
     pool: PgPool,
@@ -43,11 +14,8 @@ impl SqlxRunRepository {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
     }
-}
 
-#[async_trait]
-impl RunRepository for SqlxRunRepository {
-    async fn find_by_id(&self, id: &RunId) -> RepositoryResult<Option<Run>> {
+    pub async fn find_by_id(&self, id: &RunId) -> RepositoryResult<Option<Run>> {
         let row = sqlx::query(
             "SELECT run_id, user_id, state, workflow_type, workflow_type_version, \
             workflow_url, workflow_engine, workflow_engine_version, \
@@ -62,7 +30,7 @@ impl RunRepository for SqlxRunRepository {
         Ok(row.map(map_row_to_run))
     }
 
-    async fn find_all(
+    pub async fn find_all(
         &self,
         filter: RunFilter,
         pagination: Pagination,
@@ -135,7 +103,7 @@ impl RunRepository for SqlxRunRepository {
         Ok(calculate_next_token(runs, pagination.page_size, offset))
     }
 
-    async fn count_by_state(&self) -> RepositoryResult<HashMap<String, i64>> {
+    pub async fn count_by_state(&self) -> RepositoryResult<HashMap<String, i64>> {
         let rows = sqlx::query(
             "SELECT state, COUNT(*) as count FROM runs WHERE deleted_at IS NULL GROUP BY state",
         )
@@ -148,7 +116,7 @@ impl RunRepository for SqlxRunRepository {
             .collect())
     }
 
-    async fn insert_run(
+    pub async fn insert_run(
         &self,
         run_id: &str,
         user_id: &str,
@@ -191,7 +159,7 @@ impl RunRepository for SqlxRunRepository {
         Ok(())
     }
 
-    async fn update_state(&self, id: &RunId, state: State) -> RepositoryResult<()> {
+    pub async fn update_state(&self, id: &RunId, state: State) -> RepositoryResult<()> {
         sqlx::query("UPDATE runs SET state = $1 WHERE run_id = $2")
             .bind(state.to_string())
             .bind(id.as_str())
@@ -200,7 +168,7 @@ impl RunRepository for SqlxRunRepository {
         Ok(())
     }
 
-    async fn update_state_if(
+    pub async fn update_state_if(
         &self,
         id: &RunId,
         expected: State,
@@ -215,7 +183,7 @@ impl RunRepository for SqlxRunRepository {
         Ok(result.rows_affected() > 0)
     }
 
-    async fn find_active_runs(&self) -> RepositoryResult<Vec<Run>> {
+    pub async fn find_active_runs(&self) -> RepositoryResult<Vec<Run>> {
         let rows = sqlx::query(
             r#"
             SELECT run_id, user_id, state, workflow_type, workflow_type_version,
@@ -232,7 +200,7 @@ impl RunRepository for SqlxRunRepository {
         Ok(rows.into_iter().map(map_row_to_run).collect())
     }
 
-    async fn finalize_orphaned_run(&self, id: &RunId, state: State) -> RepositoryResult<()> {
+    pub async fn finalize_orphaned_run(&self, id: &RunId, state: State) -> RepositoryResult<()> {
         sqlx::query("UPDATE runs SET state = $1, end_time = NOW() WHERE run_id = $2")
             .bind(state.to_string())
             .bind(id.as_str())
@@ -241,7 +209,7 @@ impl RunRepository for SqlxRunRepository {
         Ok(())
     }
 
-    async fn soft_delete(&self, id: &RunId) -> RepositoryResult<bool> {
+    pub async fn soft_delete(&self, id: &RunId) -> RepositoryResult<bool> {
         let result = sqlx::query(
             "UPDATE runs SET deleted_at = NOW() WHERE run_id = $1 AND deleted_at IS NULL",
         )
@@ -251,7 +219,10 @@ impl RunRepository for SqlxRunRepository {
         Ok(result.rows_affected() > 0)
     }
 
-    async fn find_run_log(&self, run_id: &RunId) -> RepositoryResult<Option<common::models::Log>> {
+    pub async fn find_run_log(
+        &self,
+        run_id: &RunId,
+    ) -> RepositoryResult<Option<common::models::Log>> {
         let row = sqlx::query(
             "SELECT name, cmd, start_time::text as start_time, end_time::text as end_time, \
             stdout, stderr, exit_code, system_logs \

--- a/crates/api/src/repositories/task.rs
+++ b/crates/api/src/repositories/task.rs
@@ -1,20 +1,9 @@
-use async_trait::async_trait;
 use sqlx::{PgPool, Row};
 
 use super::{
     PaginatedResult, Pagination, RepositoryResult, RunId, Task, TaskId, calculate_next_token,
     pagination_offset,
 };
-
-#[async_trait]
-pub trait TaskRepository: Send + Sync {
-    async fn find_by_id(&self, run_id: &RunId, task_id: &TaskId) -> RepositoryResult<Option<Task>>;
-    async fn find_by_run(
-        &self,
-        run_id: &RunId,
-        pagination: Pagination,
-    ) -> RepositoryResult<PaginatedResult<Task>>;
-}
 
 pub struct SqlxTaskRepository {
     pool: PgPool,
@@ -26,9 +15,12 @@ impl SqlxTaskRepository {
     }
 }
 
-#[async_trait]
-impl TaskRepository for SqlxTaskRepository {
-    async fn find_by_id(&self, run_id: &RunId, task_id: &TaskId) -> RepositoryResult<Option<Task>> {
+impl SqlxTaskRepository {
+    pub async fn find_by_id(
+        &self,
+        run_id: &RunId,
+        task_id: &TaskId,
+    ) -> RepositoryResult<Option<Task>> {
         let row = sqlx::query(
             r#"
             SELECT
@@ -46,7 +38,7 @@ impl TaskRepository for SqlxTaskRepository {
         Ok(row.map(map_row_to_task))
     }
 
-    async fn find_by_run(
+    pub async fn find_by_run(
         &self,
         run_id: &RunId,
         pagination: Pagination,

--- a/crates/api/src/services/log.rs
+++ b/crates/api/src/services/log.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
 use super::ServiceResult;
-use crate::repositories::{LogLine, LogRepository, LogStream, PaginatedResult, RunId};
+use crate::repositories::{LogLine, LogStream, PaginatedResult, RunId, SqlxLogRepository};
 
 #[derive(Clone)]
 pub struct LogService {
-    repo: Arc<dyn LogRepository>,
+    repo: Arc<SqlxLogRepository>,
 }
 
 impl LogService {
-    pub fn new(repo: Arc<dyn LogRepository>) -> Self {
+    pub fn new(repo: Arc<SqlxLogRepository>) -> Self {
         Self { repo }
     }
 

--- a/crates/api/src/services/run.rs
+++ b/crates/api/src/services/run.rs
@@ -5,19 +5,19 @@ use common::validators::EngineRequestValidator;
 
 use super::ServiceResult;
 use crate::infrastructure::{NatsPublisher, RedisClient};
-use crate::repositories::{PaginatedResult, Pagination, Run, RunFilter, RunId, RunRepository};
+use crate::repositories::{PaginatedResult, Pagination, Run, RunFilter, RunId, SqlxRunRepository};
 use crate::services::ServiceError;
 
 #[derive(Clone)]
 pub struct RunService {
-    repo: Arc<dyn RunRepository>,
+    repo: Arc<SqlxRunRepository>,
     nats: Arc<NatsPublisher>,
     redis: Arc<RedisClient>,
 }
 
 impl RunService {
     pub fn with_messaging(
-        repo: Arc<dyn RunRepository>,
+        repo: Arc<SqlxRunRepository>,
         nats: Arc<NatsPublisher>,
         redis: Arc<RedisClient>,
     ) -> Self {

--- a/crates/api/src/services/service_info.rs
+++ b/crates/api/src/services/service_info.rs
@@ -5,17 +5,17 @@ use common::models::{EngineInfo, ServiceInfo, WorkflowEngineVersion, WorkflowTyp
 use super::ServiceResult;
 use crate::config::Config;
 use crate::infrastructure::RedisClient;
-use crate::repositories::RunRepository;
+use crate::repositories::SqlxRunRepository;
 
 #[derive(Clone)]
 pub struct ServiceInfoService {
-    repo: Arc<dyn RunRepository>,
+    repo: Arc<SqlxRunRepository>,
     redis: Arc<RedisClient>,
     config: Config,
 }
 
 impl ServiceInfoService {
-    pub fn new(repo: Arc<dyn RunRepository>, redis: Arc<RedisClient>, config: Config) -> Self {
+    pub fn new(repo: Arc<SqlxRunRepository>, redis: Arc<RedisClient>, config: Config) -> Self {
         Self { repo, redis, config }
     }
 

--- a/crates/api/src/services/task.rs
+++ b/crates/api/src/services/task.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
 use super::ServiceResult;
-use crate::repositories::{PaginatedResult, Pagination, RunId, Task, TaskId, TaskRepository};
+use crate::repositories::{PaginatedResult, Pagination, RunId, SqlxTaskRepository, Task, TaskId};
 
 #[derive(Clone)]
 pub struct TaskService {
-    repo: Arc<dyn TaskRepository>,
+    repo: Arc<SqlxTaskRepository>,
 }
 
 impl TaskService {
-    pub fn new(repo: Arc<dyn TaskRepository>) -> Self {
+    pub fn new(repo: Arc<SqlxTaskRepository>) -> Self {
         Self { repo }
     }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3,7 +3,7 @@
 Metis closely follows the [GA4GH WES 1.1.0](https://ga4gh.github.io/workflow-execution-service-schemas/) standard,
 extending it with SSE streaming, log pagination, and soft-delete.
 
-::: note live documentation
+:::info live documentation
 Interactive API documentation is available at `http://<host>:<port>/docs`
 when the API is running. It contains the complete and most up-to-date
 request and response schemas. This page is provided for reference only


### PR DESCRIPTION
Traits are not needed as this is a simple
API and they we making it complex for no reason

#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #(issue number)

<!-- Example:

Fixes #1
Fixes #2

- Address bug X by Y
- Add support for feature X through Y
-->

#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

## Summary by Sourcery

Simplify the API repository layer by inlining concrete SQLx repositories and removing unnecessary async traits and trait-based abstractions.

Enhancements:
- Replace trait-based repository interfaces with direct use of concrete Sqlx*Repository types across services to reduce indirection and complexity.
- Expose repository methods on SqlxRunRepository, SqlxTaskRepository, and SqlxLogRepository as public async functions instead of trait implementations.
- Remove the async-trait dependency from the API crate as it is no longer needed.